### PR TITLE
Portability: GLOO/TP socket ifnames, KV dtype override, and notes from a non-author host

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -146,9 +146,10 @@ VLLM_SKIP_INIT_MEMORY_CHECK=1
 #GLOO_SOCKET_IFNAME=
 #TP_SOCKET_IFNAME=
 
-# Serve weights already on disk (skips the HF download path).
-# DSPARK_MODEL must then point inside the mount, e.g. /models/<dir>,
-# and must not be a symlink to a path outside it.
+# Serve weights already on disk (skips the HF download path). The launcher
+# scps this env file to the worker and runs both nodes with --env-file, so a
+# value here reaches head and worker alike. DSPARK_MODEL must then point inside
+# the mount, e.g. /models/<dir>, and must not be a symlink to a path outside it.
 #LOCAL_MODELS_DIR=/data/models
 
 # nvfp4_ds_mla gives the 1M pool; fp8_ds_mla is the conservative choice

--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -138,3 +138,19 @@ NCCL_DEBUG=WARN
 NCCL_NVLS_ENABLE=0
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 VLLM_SKIP_INIT_MEMORY_CHECK=1
+
+# --- portability on hosts other than the author's ---
+# The base image bakes the author's NIC into GLOO_SOCKET_IFNAME and
+# TP_SOCKET_IFNAME. Leave these unset to inherit NCCL_SOCKET_IFNAME
+# (the compose file now does that), or set them explicitly:
+#GLOO_SOCKET_IFNAME=
+#TP_SOCKET_IFNAME=
+
+# Serve weights already on disk (skips the HF download path).
+# DSPARK_MODEL must then point inside the mount, e.g. /models/<dir>,
+# and must not be a symlink to a path outside it.
+#LOCAL_MODELS_DIR=/data/models
+
+# nvfp4_ds_mla gives the 1M pool; fp8_ds_mla is the conservative choice
+# when 4-bit KV quality under long agentic context matters more than reach.
+#KV_CACHE_DTYPE=nvfp4_ds_mla

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -15,6 +15,14 @@ services:
       - /dev/infiniband:/dev/infiniband
 
     volumes:
+      # To serve weights already on disk instead of the HF cache, set
+      # LOCAL_MODELS_DIR=/data/models in .env.dspark and add an override file
+      # (docker-compose.local-models.yml) with:
+      #     services: {vllm-dspark: {volumes: ["${LOCAL_MODELS_DIR}:/models:ro"]}}
+      # then point DSPARK_MODEL at /models/<dir>. That directory must be real —
+      # a symlink to a path outside the mount resolves to something the container
+      # cannot see and vLLM falls back to treating it as an HF repo id
+      # (HFValidationError: Repo id must be in the form ...).
       - ${HF_CACHE:-${HOME}/.cache/huggingface}:/cache/huggingface
       # DSpark source patches are baked into the image from recipe/overlay/
       # (see README "vLLM version note"); do not bind-mount a proposer copy
@@ -71,6 +79,12 @@ services:
       NCCL_IB_DISABLE: "${NCCL_IB_DISABLE:-0}"
       NCCL_IB_HCA: "${NCCL_IB_HCA}"
       NCCL_SOCKET_IFNAME: "${NCCL_SOCKET_IFNAME}"
+      # The base image bakes GLOO_SOCKET_IFNAME/TP_SOCKET_IFNAME for the
+      # author's NIC. On any other host those interfaces do not exist and
+      # rank init dies in ProcessGroupGloo (gloo/transport/tcp/device.cc).
+      # Default to the NCCL interface so a single .env value covers all three.
+      GLOO_SOCKET_IFNAME: "${GLOO_SOCKET_IFNAME:-${NCCL_SOCKET_IFNAME}}"
+      TP_SOCKET_IFNAME: "${TP_SOCKET_IFNAME:-${NCCL_SOCKET_IFNAME}}"
       NCCL_IB_GID_INDEX: "${NCCL_IB_GID_INDEX:-}"
       NCCL_CROSS_NIC: "${NCCL_CROSS_NIC:-1}"
       NCCL_CUMEM_ENABLE: "${NCCL_CUMEM_ENABLE:-0}"
@@ -101,7 +115,7 @@ services:
         --trust-remote-code
         --tensor-parallel-size 2
         --pipeline-parallel-size 1
-        --kv-cache-dtype nvfp4_ds_mla
+        --kv-cache-dtype ${KV_CACHE_DTYPE:-nvfp4_ds_mla}
         --block-size 256
         --max-model-len ${MAX_MODEL_LEN:-1048576}
         --max-num-seqs ${MAX_NUM_SEQS:-6}

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -15,14 +15,17 @@ services:
       - /dev/infiniband:/dev/infiniband
 
     volumes:
-      # To serve weights already on disk instead of the HF cache, set
-      # LOCAL_MODELS_DIR=/data/models in .env.dspark and add an override file
-      # (docker-compose.local-models.yml) with:
-      #     services: {vllm-dspark: {volumes: ["${LOCAL_MODELS_DIR}:/models:ro"]}}
-      # then point DSPARK_MODEL at /models/<dir>. That directory must be real —
-      # a symlink to a path outside the mount resolves to something the container
-      # cannot see and vLLM falls back to treating it as an HF repo id
+      # Serve weights already on disk instead of downloading through the HF
+      # cache: set LOCAL_MODELS_DIR in .env.dspark (it reaches both nodes, since
+      # the launcher passes the env file to worker and head) and point
+      # DSPARK_MODEL at /models/<dir>. Defaults to the HF cache dir, so leaving
+      # it unset mounts nothing new.
+      #
+      # DSPARK_MODEL must name a real directory inside the mount — a symlink
+      # whose target lies outside it resolves to a host path the container
+      # cannot see, and vLLM then treats the value as an HF repo id
       # (HFValidationError: Repo id must be in the form ...).
+      - ${LOCAL_MODELS_DIR:-${HF_CACHE:-${HOME}/.cache/huggingface}}:/models:ro
       - ${HF_CACHE:-${HOME}/.cache/huggingface}:/cache/huggingface
       # DSpark source patches are baked into the image from recipe/overlay/
       # (see README "vLLM version note"); do not bind-mount a proposer copy

--- a/docs/PORTABILITY.md
+++ b/docs/PORTABILITY.md
@@ -1,0 +1,112 @@
+# Running this recipe on hardware other than the author's
+
+Notes from a clean-room bring-up on 2× DGX Spark (GB10 sm_121a, 200G CX7) that is
+not the machine this recipe was developed on. The recipe itself is correct — these
+are the places where a different host trips over an assumption. Numbers below were
+measured on the `deepseek-ai/DeepSeek-V4-Flash-0731` checkpoint with the Stage-C
+runtime + the nvfp4 chain, DSpark k=5 probabilistic, 1M context.
+
+## 1. `nvfp4_ds_mla` lives in the three-stage image, not the overlay
+
+Building only `recipe/Dockerfile.dspark-runtime-overlay` gives an image whose vLLM
+rejects the KV dtype:
+
+```
+vllm serve: error: argument --kv-cache-dtype: invalid choice: 'nvfp4_ds_mla'
+  (choose from auto, bfloat16, float16, fp8, fp8_ds_mla, ...)
+```
+
+The dtype comes from `recipe/nvfp4/Dockerfile.stage-{a,b,c}`, chained on top of the
+overlay. A one-line note near the build instructions would save the boot cycle.
+
+## 2. The launcher uses the root compose file
+
+`start-deepseek-v4-flash-dspark.sh` defaults to `./docker-compose.dspark.yml`.
+Edits made to `verified-deployed-2026-07-04/docker-compose.dspark.yml` are silently
+ignored — easy to lose time on when both files exist and look equivalent.
+
+## 3. `GLOO_SOCKET_IFNAME` / `TP_SOCKET_IFNAME` are baked into the base image
+
+The base image ships these pointing at the author's NIC. On another host that
+interface is down or absent and rank init dies in:
+
+```
+RuntimeError: [enforce fail at /pytorch/third_party/gloo/gloo/transport/tcp/device.cc]
+```
+
+The compose file passes `NCCL_SOCKET_IFNAME` through but not these two, so a correct
+`.env.dspark` still boots into the failure. **This PR defaults both to
+`NCCL_SOCKET_IFNAME`**, which makes one value in `.env.dspark` cover all three.
+
+## 4. `DSPARK_MODEL` and symlinks
+
+Serving weights already on disk needs a bind mount (the compose assumes the HF cache
+path). Once mounted, `DSPARK_MODEL` must be a real directory inside the mount — a
+symlink whose target is a host path outside it resolves to nothing the container can
+see, and vLLM falls back to treating the value as a repo id:
+
+```
+huggingface_hub.errors.HFValidationError: Repo id must be in the form ...
+```
+
+This PR documents the override-file pattern for the mount rather than adding an
+unconditional volume, so nothing changes for HF-cache users.
+
+## 5. systemd needs `HOME`
+
+`.env.dspark` expands `${HOME}` (for `HF_CACHE`). Under a systemd unit `HOME` is
+unset and the launcher aborts with `HOME: unbound variable`. Adding
+`Environment=HOME=/root` to the unit fixes it.
+
+## 6. GB10 power state after a reboot (not a recipe bug, but it looks like one)
+
+Worth flagging because the symptom mimics a bad config. After one of our nodes
+crashed and rebooted, it sat at ~22 W / 2086 MHz under load while the healthy node
+ran ~42 W / 2502 MHz. Because TP=2 is lockstep, the pair ran at the slow node's pace:
+
+| | peak decode | step latency | DSpark acceptance |
+|---|---|---|---|
+| degraded node in the pair | 42–43 tok/s | ~140 ms | 6.02 tok/step (already optimal) |
+| after `nvidia-smi -lgc 3003` on both | **83 tok/s** | ~72 ms | unchanged |
+
+Acceptance was perfect the whole time, which is what makes this confusing — the
+drafter and the config are fine; only the clock is wrong. A quick check under load:
+
+```bash
+nvidia-smi --query-gpu=clocks.sm,power.draw --format=csv,noheader
+# asymmetry between the two nodes => this
+```
+
+## 7. `--default-chat-template-kwargs '{"thinking":false}'`
+
+Not a bug — the recipe optimises for throughput. But it is worth stating loudly,
+because the checkpoint has no Jinja chat template (it ships `encoding/` scripts), so
+the only thing that turns reasoning back on is:
+
+```json
+"chat_template_kwargs": {"thinking": true, "reasoning_effort": "high"}
+```
+
+Top-level `reasoning_effort` is ignored. Levels are `low` (default) / `high` / `max`.
+
+Measured on our own execution-graded harness (LiveCodeBench-style, 20 frozen
+problems, 3 public + up to 40 private tests per problem, a problem counts only when
+every private test passes; plus a procedural seed-generated suite of 48 cases):
+
+| | procedural suite | LCB, one-shot | LCB, after a 32k-token retry of the failures |
+|---|---|---|---|
+| thinking off (recipe default) | 0.875 | 12/20 | 13/20 |
+| **thinking on, effort high** | **0.979** | 11/20 | **20/20** |
+
+The one-shot number goes *down* when reasoning is enabled — with an 8k cap the model
+spends the budget thinking and gets truncated. Every one of the nine failures was
+`finish_reason=length`, and all nine passed once retried with a 32k budget. Anyone
+benchmarking this checkpoint should report the thinking setting and retry
+length-capped failures, or the result measures the cap rather than the model.
+
+## 8. Streamed reasoning field name
+
+The runtime emits `delta.reasoning`; OpenAI-compatible clients expect
+`delta.reasoning_content`. Clients that render a reasoning panel sit on "Thinking…"
+until the whole response lands. A small translating proxy in front of the server is
+enough; noting it in the README would spare people the debugging.


### PR DESCRIPTION
Thanks for this recipe — it is the only path that got the 0731 checkpoint serving on our pair of Sparks, and the Patch 4 write-up in particular saved us a lot of guessing.

Bringing it up on hardware that is not yours surfaced a handful of places where a different host hits a baked-in assumption. Everything here defaults to current behaviour, so existing deployments are unaffected.

### compose

- **`GLOO_SOCKET_IFNAME` / `TP_SOCKET_IFNAME` passthrough** (defaulting to `NCCL_SOCKET_IFNAME`). The base image ships these pointing at your NIC. On another host that interface is down, and rank init dies in `ProcessGroupGloo` (`gloo/transport/tcp/device.cc`) *even with a correct `.env.dspark`* — the compose file passes `NCCL_SOCKET_IFNAME` through but not these two. This was the last blocker for us.
- **`--kv-cache-dtype` overridable** via `KV_CACHE_DTYPE`, still `nvfp4_ds_mla` by default.
- **Comment documenting the override-file pattern** for serving weights already on disk, plus the symlink caveat (a symlink whose target is outside the mount makes vLLM treat `DSPARK_MODEL` as a repo id → `HFValidationError`).

### docs/PORTABILITY.md

The full list, including two things that are not recipe bugs but read exactly like one:

**GB10 power state after a reboot.** One of our nodes had crashed and came back sitting at ~22 W / 2086 MHz under load while the healthy node ran ~42 W / 2502 MHz. TP=2 is lockstep, so the pair ran at the slow node's pace — 42 tok/s peak, ~140 ms per step — *with DSpark acceptance already perfect at 6.02 tok/step*. That combination is what made it confusing: the drafter and the config were fine. `nvidia-smi -lgc 3003` on both nodes took it to 83 tok/s. Might be worth a line in the troubleshooting section, since the symptom looks like a serving misconfiguration.

**The `thinking:false` default and benchmark numbers.** Understood as a throughput choice, and not something this PR changes. But since the checkpoint has no Jinja template (it ships `encoding/` scripts), the only thing that re-enables reasoning is `chat_template_kwargs: {"thinking": true, "reasoning_effort": "high"}` — top-level `reasoning_effort` is silently ignored.

Measured on our own execution-graded harness (20 frozen LiveCodeBench-style problems, 3 public + up to 40 private tests each, a problem counts only when every private test passes; plus 48 procedurally generated cases):

| | procedural suite | LCB one-shot | LCB after retrying failures at 32k |
|---|---|---|---|
| thinking off (shipped default) | 0.875 | 12/20 | 13/20 |
| thinking on, effort high | **0.979** | 11/20 | **20/20** |

The one-shot number moves *down* with reasoning enabled — at an 8k cap the model spends the budget thinking and gets truncated. All nine failures were `finish_reason=length`, and all nine passed on retry with a 32k budget. Worth flagging for anyone benchmarking this checkpoint.

### also noted in the doc

- `nvfp4_ds_mla` only exists after the three-stage `recipe/nvfp4/` chain, not the overlay build alone
- the launcher uses the root `docker-compose.dspark.yml`, not the one under `verified-deployed-*/`
- systemd units need `Environment=HOME=/root` (`.env.dspark` expands `${HOME}`)
- the runtime emits `delta.reasoning`; OpenAI-compatible clients expect `delta.reasoning_content`, so reasoning panels hang until the response completes

Happy to split this into smaller PRs, drop the doc, or reword anything that misreads your intent.