### PR TITLE
Clarify two-node startup and provide verified env examples

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -1,5 +1,23 @@
 # DeepSeek V4 Flash DSpark C12 NVFP4 profile for 2x DGX Spark TP=2.
-# Copy to .env.dspark on each node and adjust node-specific values.
+# Copy this file to .env.dspark on the HEAD node. The head-side launcher
+# synchronizes it to the worker and overrides NODE_RANK, HEADLESS, HF_CACHE,
+# and VLLM_HOST_IP for rank 1; do not maintain a second worker copy by hand.
+#
+# Known-working topology example from the verified 2026-07-04 deployment.
+# These are examples, not defaults: replace the user, addresses, and paths
+# with values from your two nodes. The runtime values later in this file are
+# already the current known-working profile.
+#   WORKER_HOST=tonyspark4@192.168.192.4
+#   WORKER_SCRIPT_DIR=/home/tonyspark4/ds4-repo-patch3
+#   MASTER_ADDR=192.168.192.3
+#   MASTER_PORT=25440
+#   NCCL_IB_HCA=rocep1s0f0
+#   NCCL_SOCKET_IFNAME=enp1s0f0np0
+#   NCCL_IB_GID_INDEX=3
+#   HF_CACHE=/home/tonyspark3/.cache/huggingface
+#   WORKER_HF_CACHE=/home/tonyspark4/.cache/huggingface
+#   VLLM_HOST_IP=192.168.192.3
+#   WORKER_VLLM_HOST_IP=192.168.192.4
 
 # Cluster
 WORKER_HOST=worker-host-or-roce-ip

--- a/README.md
+++ b/README.md
@@ -176,7 +176,10 @@ acceptance problem: check Patch 4 before anything else.
 
 ## Quick start
 
-Run from the head node.
+Run every command in this section **once, on the head node only**. The launch
+script connects to `WORKER_HOST` over SSH, copies the deployment files, starts
+rank 1 on the worker first, and then starts rank 0 locally. Do not run the
+launch script separately on both nodes.
 
 ```bash
 cp .env.dspark.example .env.dspark
@@ -194,12 +197,33 @@ Edit these values for your cluster:
 - `WORKER_HF_CACHE` if the worker cache path differs from the head
 - `VLLM_HOST_IP` and `WORKER_VLLM_HOST_IP` for each node's fabric IP
 
-Then build, prepare the cache, and start (worker-first):
+The editable values are different kinds of identifiers; do not substitute the
+management Ethernet address where a RoCE address is required:
+
+| variable | expected value | verified topology example |
+|---|---|---|
+| `WORKER_HOST` | SSH target for the worker | `tonyspark4@192.168.192.4` |
+| `MASTER_ADDR` | head-node **RoCE fabric IPv4 address** | `192.168.192.3` |
+| `NCCL_IB_HCA` | RDMA/HCA device name | `rocep1s0f0` |
+| `NCCL_SOCKET_IFNAME` | Linux network interface associated with that fabric | `enp1s0f0np0` |
+| `NCCL_IB_GID_INDEX` | decimal GID-table index, not an address or interface | `3` |
+| `HF_CACHE` | absolute head-node cache path | `/home/tonyspark3/.cache/huggingface` |
+| `WORKER_HF_CACHE` | absolute worker cache path | `/home/tonyspark4/.cache/huggingface` |
+| `VLLM_HOST_IP` | head-node RoCE fabric IPv4 address | `192.168.192.3` |
+| `WORKER_VLLM_HOST_IP` | worker-node RoCE fabric IPv4 address | `192.168.192.4` |
+
+These are real values from the verified 2026-07-04 deployment, not addresses
+that should be copied onto another network. The current known-working runtime
+values are already populated in `.env.dspark.example`; only the cluster,
+fabric, and path placeholders need site-specific edits.
+
+Validate the edited file, then build, prepare the cache, and start:
 
 ```bash
-./build-dspark-vllm-runtime.sh      # builds the base overlay + Stage C NVFP4 image
-./prepare-dspark-model-cache.sh     # downloads/verifies the model cache
-./start-deepseek-v4-flash-dspark.sh # worker-first launch and smoke test
+./validate-dspark-config.sh          # rejects placeholders/types and renders compose
+./build-dspark-vllm-runtime.sh       # builds locally and on the worker
+./prepare-dspark-model-cache.sh      # downloads locally and mirrors to the worker
+./start-deepseek-v4-flash-dspark.sh  # starts worker, then head; waits for API + smoke
 ```
 
 The API serves at:
@@ -223,7 +247,7 @@ Keep these `.env.dspark` values unless you are deliberately experimenting:
 - `MAX_MODEL_LEN=1048576` — **1M, the model's true YaRN ceiling** (see the note above)
 - `MAX_NUM_SEQS=12`
 - `GPU_MEMORY_UTILIZATION=0.85`
-- `MTP_NUM_TOKENS=3` (with `draft_sample_method=probabilistic`; see the [garble fix](#garble-fix-2026-07-03))
+- `MTP_NUM_TOKENS=5` — the verified Patch-3 default
 - `VLLM_DSPARK_GPU_REJECTED_CONTEXT_MASK=1`
 - `VLLM_USE_B12X_WO_PROJECTION=1`
 - `VLLM_USE_FLASHINFER_SAMPLER=1`
@@ -274,6 +298,8 @@ Keep these `.env.dspark` values unless you are deliberately experimenting:
 ./start-deepseek-v4-flash-dspark.sh
 ```
 
+Run this command **once on the head node**. It launches rank 1 through SSH
+before launching rank 0 locally; you do not run it again on the worker.
 Worker-first startup avoids a race during multi-node `mp` initialization. The
 launcher runs `--generation-config vllm` with **no** `--override-generation-config`
 and `--default-chat-template-kwargs '{"thinking":false}'`. Exact flags and env
@@ -285,32 +311,44 @@ Other lifecycle scripts: `stop-deepseek-v4-flash-dspark.sh`,
 `smoke-deepseek-v4-flash-dspark.sh`, `validate-dspark-config.sh`,
 `update-and-restart.sh`.
 
-### Verify
+### Verify and understand startup
 
-After launch:
+`start-deepseek-v4-flash-dspark.sh` waits for the API and runs a smoke request.
+A cold boot can take several minutes for model loading, compilation, CUDA-graph
+capture, and first-use kernel/JIT caching. In a second terminal on the **head
+node**, inspect both nodes without maintaining two SSH sessions:
+
+```bash
+./status-deepseek-v4-flash-dspark.sh
+./logs-deepseek-v4-flash-dspark.sh
+```
+
+The log helper returns a recent snapshot from both rank 0 and rank 1. By
+contrast, this manual command follows **rank 0 only** and intentionally does
+not return until you press Ctrl-C:
+
+```bash
+docker compose --env-file .env.dspark -f docker-compose.dspark.yml \
+  logs -f vllm-dspark
+```
+
+Run that manual `logs -f` command separately on the worker only if you want a
+second live follower. A final-looking line such as:
+
+```text
+world_size=2 rank=0 local_rank=0 distributed_init_method=tcp://HEAD_ROCE_IP:MASTER_PORT
+```
+
+usually means rank 0 is waiting for rank 1 to join NCCL; it is not a completion
+message and `logs -f` itself is not hung. If it does not advance after several
+minutes, use the two helper scripts above and verify that the worker container
+is running and both ranks agree on `MASTER_ADDR`, `MASTER_PORT`, HCA, socket
+interface, and GID index.
+
+After launch, the current default should report `max_model_len: 1048576`:
 
 ```bash
 curl -fsS http://127.0.0.1:8888/v1/models
-```
-
-Confirm the returned model entry reports (C12 1.5M checkpoint):
-
-```json
-"max_model_len": 1500000
-```
-
-Then check logs:
-
-```bash
-docker compose --env-file .env.dspark -f docker-compose.dspark.yml logs vllm-dspark \
-  | grep -E "GPU KV cache size|Maximum concurrency"
-```
-
-Expected C12 checkpoint values are around:
-
-```text
-GPU KV cache size: 3.2M tokens
-Maximum concurrency for 1,500,000 tokens per request: 2.1x
 ```
 
 Before pointing an agent harness at the endpoint, run the direct sanity bench:
@@ -1071,7 +1109,7 @@ recipe.
 | `start-deepseek-v4-flash-dspark.sh` | worker-first launch and smoke test; honors worker path/cache/IP overrides |
 | `stop-deepseek-v4-flash-dspark.sh` | stops head and worker services |
 | `status-deepseek-v4-flash-dspark.sh` | shows head/worker container state |
-| `logs-deepseek-v4-flash-dspark.sh` | tails head/worker DSpark logs |
+| `logs-deepseek-v4-flash-dspark.sh` | shows recent rank-0 and rank-1 logs when run on the head |
 | `smoke-deepseek-v4-flash-dspark.sh` | direct concurrent OpenAI-compatible smoke test |
 | `validate-dspark-config.sh` | renders and checks the local DSpark compose/env config |
 | `patches/keys-concurrency.patch` | full path-adjusted Keys concurrency patch reference |

--- a/start-deepseek-v4-flash-dspark.sh
+++ b/start-deepseek-v4-flash-dspark.sh
@@ -26,6 +26,10 @@ set +a
 : "${VLLM_HOST_IP:?VLLM_HOST_IP must be set to the head node fabric IP in $ENV_FILE}"
 : "${WORKER_VLLM_HOST_IP:?WORKER_VLLM_HOST_IP must be set to the worker node fabric IP in $ENV_FILE}"
 
+if [ "${SKIP_CONFIG_VALIDATION:-0}" != "1" ]; then
+  "$SCRIPT_DIR/validate-dspark-config.sh"
+fi
+
 cd "$SCRIPT_DIR"
 
 # DSpark source patches ship inside the runtime image (recipe/overlay/), not
@@ -73,8 +77,15 @@ ssh "$WORKER_HOST" "$REMOTE_COMPOSE NODE_RANK=1 HEADLESS=1 HF_CACHE='$WORKER_HF_
 echo "Starting DSpark head..."
 COMPOSE_DISABLE_ENV_FILE=1 NODE_RANK=0 HEADLESS= docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
 
+echo "Both ranks have been started. Run this launcher only on the head node."
+echo "A cold start can spend several minutes loading weights and compiling/capturing kernels."
+echo "Rank 0 may pause at 'world_size=2 ... distributed_init_method=...' while rank 1 joins; this is expected."
+echo "For recent logs from both nodes, run in another head-node terminal:"
+echo "  $SCRIPT_DIR/logs-deepseek-v4-flash-dspark.sh"
+echo "The readiness wait below allows up to $((WAIT_ATTEMPTS * WAIT_SECONDS)) seconds."
+
 echo "Waiting for DSpark vLLM API..."
-for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
+for attempt in $(seq 1 "$WAIT_ATTEMPTS"); do
   if curl -fsS --max-time 5 "$API_URL" >/dev/null; then
     echo "DeepSeek V4 Flash DSpark is running: $API_URL"
     COMPOSE_DISABLE_ENV_FILE=1 docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" ps
@@ -85,6 +96,9 @@ for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
       -d '{"model":"'"${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"'","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":8,"temperature":0.0}' >/dev/null
     echo "Minimal chat request succeeded."
     exit 0
+  fi
+  if ((attempt % 4 == 0)); then
+    echo "Still waiting for the API ($((attempt * WAIT_SECONDS)) seconds elapsed)..."
   fi
   sleep "$WAIT_SECONDS"
 done

--- a/validate-dspark-config.sh
+++ b/validate-dspark-config.sh
@@ -5,6 +5,48 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/.env.dspark}"
 COMPOSE_FILE="${COMPOSE_FILE:-$SCRIPT_DIR/docker-compose.dspark.yml}"
 
+fail() {
+  echo "Invalid DSpark config: $*" >&2
+  exit 1
+}
+
+reject_placeholder() {
+  local name="$1"
+  local value="$2"
+  case "$value" in
+    *-roce-ip | worker-host-or-roce-ip | rocepXsYfZ | enpXsYfZnpN)
+      fail "$name still has the example placeholder '$value'"
+      ;;
+  esac
+}
+
+require_ipv4() {
+  local name="$1"
+  local value="$2"
+  local octet
+  local -a octets
+  [[ "$value" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] ||
+    fail "$name must be an IPv4 fabric address, got '$value'"
+  IFS=. read -r -a octets <<<"$value"
+  for octet in "${octets[@]}"; do
+    ((10#$octet <= 255)) || fail "$name has an invalid IPv4 octet in '$value'"
+  done
+}
+
+require_uint() {
+  local name="$1"
+  local value="$2"
+  [[ "$value" =~ ^[0-9]+$ ]] ||
+    fail "$name must be a decimal integer, got '$value'"
+}
+
+require_absolute_path() {
+  local name="$1"
+  local value="$2"
+  [[ "$value" = /* ]] ||
+    fail "$name must be an absolute path, got '$value'"
+}
+
 if [ ! -f "$ENV_FILE" ]; then
   echo "Missing $ENV_FILE. Copy .env.dspark.example to .env.dspark and edit it." >&2
   exit 1
@@ -23,7 +65,35 @@ set +a
 : "${WORKER_HOST:?WORKER_HOST must be set in $ENV_FILE}"
 : "${MASTER_ADDR:?MASTER_ADDR must be set in $ENV_FILE}"
 : "${MASTER_PORT:?MASTER_PORT must be set in $ENV_FILE}"
+: "${NCCL_IB_HCA:?NCCL_IB_HCA must be set in $ENV_FILE}"
+: "${NCCL_SOCKET_IFNAME:?NCCL_SOCKET_IFNAME must be set in $ENV_FILE}"
+: "${NCCL_IB_GID_INDEX:?NCCL_IB_GID_INDEX must be set in $ENV_FILE}"
+: "${HF_CACHE:?HF_CACHE must be set in $ENV_FILE}"
+: "${VLLM_HOST_IP:?VLLM_HOST_IP must be set in $ENV_FILE}"
+: "${WORKER_VLLM_HOST_IP:?WORKER_VLLM_HOST_IP must be set in $ENV_FILE}"
 : "${DSPARK_VLLM_IMAGE:?DSPARK_VLLM_IMAGE must be set in $ENV_FILE}"
+
+reject_placeholder WORKER_HOST "$WORKER_HOST"
+reject_placeholder MASTER_ADDR "$MASTER_ADDR"
+reject_placeholder NCCL_IB_HCA "$NCCL_IB_HCA"
+reject_placeholder NCCL_SOCKET_IFNAME "$NCCL_SOCKET_IFNAME"
+reject_placeholder VLLM_HOST_IP "$VLLM_HOST_IP"
+reject_placeholder WORKER_VLLM_HOST_IP "$WORKER_VLLM_HOST_IP"
+require_ipv4 MASTER_ADDR "$MASTER_ADDR"
+require_ipv4 VLLM_HOST_IP "$VLLM_HOST_IP"
+require_ipv4 WORKER_VLLM_HOST_IP "$WORKER_VLLM_HOST_IP"
+require_uint MASTER_PORT "$MASTER_PORT"
+require_uint NCCL_IB_GID_INDEX "$NCCL_IB_GID_INDEX"
+require_absolute_path HF_CACHE "$HF_CACHE"
+if [ -n "${WORKER_HF_CACHE:-}" ]; then
+  require_absolute_path WORKER_HF_CACHE "$WORKER_HF_CACHE"
+fi
+if [ "$VLLM_HOST_IP" = "$WORKER_VLLM_HOST_IP" ]; then
+  fail "VLLM_HOST_IP and WORKER_VLLM_HOST_IP must identify different nodes"
+fi
+if ((MASTER_PORT < 1 || MASTER_PORT > 65535)); then
+  fail "MASTER_PORT must be between 1 and 65535, got '$MASTER_PORT'"
+fi
 
 echo "DSpark config:"
 echo "  worker: ${WORKER_HOST}"
@@ -32,10 +102,10 @@ echo "  image: ${DSPARK_VLLM_IMAGE}"
 echo "  model: ${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-DSpark}"
 echo "  served model: ${SERVED_MODEL_NAME:-deepseek-v4-flash-dspark}"
 echo "  max model len: ${MAX_MODEL_LEN:-1048576}"
-echo "  max num seqs: ${MAX_NUM_SEQS:-6}"
+echo "  max num seqs: ${MAX_NUM_SEQS:-12}"
 echo "  max batched tokens: ${MAX_NUM_BATCHED_TOKENS:-8192}"
-echo "  gpu memory utilization: ${GPU_MEMORY_UTILIZATION:-0.80}"
-echo "  spec tokens (MTP_NUM_TOKENS): ${MTP_NUM_TOKENS:-3} with draft_sample_method=probabilistic"
+echo "  gpu memory utilization: ${GPU_MEMORY_UTILIZATION:-0.85}"
+echo "  spec tokens (MTP_NUM_TOKENS): ${MTP_NUM_TOKENS:-5}"
 echo "  sampling override: none (no --override-generation-config; --generation-config vllm only)"
 echo "  WO projection: ${VLLM_USE_B12X_WO_PROJECTION:-1}"
 echo "  host bind: ${VLLM_HOST:-127.0.0.1}"


### PR DESCRIPTION
Addresses tester feedback around initial configuration and startup visibility.

- adds real, known-working topology values beside each editable `.env.dspark` field
- states that setup/start commands run once on the head; the launcher starts rank 1 over SSH before rank 0
- explains that `docker compose logs -f` follows indefinitely and watches only the local rank
- explains the normal rank-0 `distributed_init_method` wait and how to inspect both nodes
- rejects untouched placeholders, malformed fabric IPv4 addresses, invalid ports/GID indexes, and relative cache paths before launch
- emits periodic cold-start progress and points to the two-node log helper
- corrects the stale detailed `MTP_NUM_TOKENS=3` statement to the verified value 5

Verification:
- `bash -n` on the lifecycle scripts
- known-working example passes `validate-dspark-config.sh` and renders compose
- untouched `.env.dspark.example` is rejected with an actionable placeholder error
- README code fences are balanced and the new guidance checks are present