### PR TITLE
sparkrun: raise VLLM_ENGINE_READY_TIMEOUT_S to 3600 for second-startup stability

### DIFF
--- a/sparkrun/deepseek-v4-flash-0731-dspark-nvfp4-1m-vllm.yaml
+++ b/sparkrun/deepseek-v4-flash-0731-dspark-nvfp4-1m-vllm.yaml
@@ -165,6 +165,9 @@ env:
   # and the failure log is empty.
   PYTHONUNBUFFERED: "1"
   # --- core runtime (mirrors upstream docker-compose.dspark.yml) ---
+  # Second-startup stability: engine-ready timeout defaults to 600 s, which
+  # trips torch.distributed teardown during warm restarts of this model.
+  VLLM_ENGINE_READY_TIMEOUT_S: "3600"
   VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
   VLLM_TRITON_MLA_SPARSE: "1"
   VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: "256"


### PR DESCRIPTION
Follow-up to #14 (per the comment thread)

Setup: Dual DGX Spark.

Description: First run works fine, and the model is served. Second run shows this error in the container logs and torch.distributed tears the world down mid-boot, and the model serve fails.

Solution: Sets `VLLM_ENGINE_READY_TIMEOUT_S: "3600"` in `sparkrun/deepseek-v4-flash-0731-dspark-nvfp4-1m-vllm.yaml` so warm restarts of the 1M recipe get a full hour to become ready.

After some detective work, this fixed the problem. 