### PR TITLE
Patch 5: don't evaluate client stop strings inside the reasoning segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ Measured on 2× DGX Spark (GB10), TP=2, k=5, `unsloth/DeepSeek-V4-Flash-0731`:
 The single residual null is mechanism (B) in [#18](../../issues/18) — a marginal-stability
 reasoning runaway, unrelated to stop strings. Patch 5 does not address it.
 
+## Patch 5 and issue #18 (B): the runaway becomes *more* visible, not less
+
+Worth stating so nobody reads it as a regression. Mechanism (B) is a reasoning runaway in
+which `</think>` never arrives. Because Patch 5 keeps stops dormant until the end marker
+appears, a request in that state now has stops dormant for its whole life and runs to
+`max_tokens` — where previously a client stop string could cut it short by accident.
+
+That is correct by design: a stop string was never meant to bound reasoning, and a run
+truncated by one was returning `content: null` anyway. But the practical effect is that
+(B) shows up as a full-budget request after this patch instead of a short one, so a fleet
+that applies Patch 5 may see *reported* token usage on those requests rise. The failure
+rate does not change; only how long each failure takes to admit it.
+
+If you are measuring (B), note that stop strings are no longer a confound in either
+direction, which is the point.
+
 Apply **[Patch 4](patches/0004-dspark-shared-expert-gate-up-proj.patch)** on top of your existing
 setup. Two lines, no rebuild — bind-mount it read-only:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,44 @@ silently drops twelve tensors, and 0731 is far more sensitive to the loss than t
 
 ### What to change
 
+## Patch 5 — stop strings must not fire inside the reasoning segment
+
+If you serve this model with a harness that sends `stop` sequences (lm-evaluation-harness
+sends `stop[:4]` on **every** request), you are almost certainly losing answers silently.
+
+vLLM's v1 detokenizer matches client stop strings against the whole output stream. With
+think-in-prompt templates, generation starts *inside* `<think>`, and chain-of-thought
+naturally restates phrases like `Question:`. The stop fires mid-reasoning, `</think>`
+never arrives, and the reasoning parser returns `content: null`. The request looks like a
+model failure; it is a serving-layer one. Hosted deployments of the same checkpoint are
+immune because they scope stops to content.
+
+Apply **[Patch 5](patches/0005-suppress-stops-in-reasoning.patch)** — bind-mount, no rebuild:
+
+```bash
+-v /path/to/patched/detokenizer.py:/opt/env/lib/python3.12/site-packages/vllm/v1/engine/detokenizer.py:ro
+```
+
+> **Both nodes.** `start-deepseek-v4-flash-dspark.sh` syncs the compose and env files to the
+> worker but **not** bind-mounted patch files. The file must exist at the same path on the
+> worker too, or it silently runs unpatched and you get confusing half-fixed results.
+
+Guard is per-request and needs no configuration: if the request's last prompt token is
+`<think>`, stop strings stay dormant until `</think>` appears. EOS and `max_tokens` are
+unaffected; non-thinking requests are untouched. Opt out with
+`VLLM_SUPPRESS_STOPS_IN_REASONING=0`.
+
+Measured on 2× DGX Spark (GB10), TP=2, k=5, `unsloth/DeepSeek-V4-Flash-0731`:
+
+| metric | before | after |
+|---|---|---|
+| decapitation reproducer (seed + stop) | 43 tok, `content: null` | 344 tok, correct answer |
+| stop honored on a non-thinking request | ✓ | ✓ (cuts at exact stop) |
+| GSM8K n=50, temp 0.6 / top_p 0.95 | 8–15 nulls, 0.66–0.84 | **1 null, 0.98** |
+
+The single residual null is mechanism (B) in [#18](../../issues/18) — a marginal-stability
+reasoning runaway, unrelated to stop strings. Patch 5 does not address it.
+
 Apply **[Patch 4](patches/0004-dspark-shared-expert-gate-up-proj.patch)** on top of your existing
 setup. Two lines, no rebuild — bind-mount it read-only:
 
@@ -261,6 +299,7 @@ image, same patches, same `k=5`, same `nvfp4_ds_mla` KV cache, same 1M context, 
 | Safety refusals | stock | removed (reported 32/32 bypass on a hard refusal suite) |
 | DSpark MTP draft modules | stock | **stock, unedited** |
 | Patch 4 | required | required |
+| Patch 5 | recommended (any stop-sending harness) | recommended |
 | On-disk | ~156 GB | ~156 GB |
 
 **Getting the uncensored weights:**

--- a/patches/0005-suppress-stops-in-reasoning.patch
+++ b/patches/0005-suppress-stops-in-reasoning.patch
@@ -18,22 +18,53 @@ WHY
 
 WHAT
   Per-request guard, no configuration required: at detokenizer construction, if
-  the request's LAST PROMPT TOKEN is `<think>`, stop strings stay dormant until
-  `</think>` appears in the output. EOS and max_tokens are unaffected.
-  Non-thinking requests are untouched by construction.
-  Opt-out: VLLM_SUPPRESS_STOPS_IN_REASONING=0
+  the request's LAST PROMPT TOKEN is the reasoning start marker, stop strings
+  stay dormant until the reasoning end marker appears in the output. EOS and
+  max_tokens are unaffected. Non-thinking requests are untouched by
+  construction.
+
+  The markers come from --reasoning-config (reasoning_start_str /
+  reasoning_end_str) when the deployment sets them, falling back to
+  <think> / </think>. The guard is therefore not DeepSeek-specific.
+
+  Opt-out: VLLM_SUPPRESS_STOPS_IN_REASONING=0. NOTE this is process-wide, not
+  per-request: a caller who deliberately wants to bound reasoning with a stop
+  string has no per-request escape hatch.
+
+SPECULATIVE DECODING (the subtle part)
+  With spec decoding update() receives up to k+1 tokens at once, so the chunk
+  that carries the end marker also carries the reasoning that preceded it. On
+  closing the guard we therefore advance stop_check_offset past the marker, so
+  stops are evaluated only over what FOLLOWS it. Without that, a stop string in
+  the last <=k tokens of reasoning still fires -- caught in review by
+  @tonyd2wild.
 
 MEASURED (2x DGX Spark GB10, TP=2, k=5 profile, unsloth/DeepSeek-V4-Flash-0731)
   decapitation reproducer (seed+stop)   43 tok, content null  ->  344 tok, correct
   stop honored on non-thinking request  ok                    ->  ok (exact cut)
   GSM8K n=50, temp 0.6 / top_p 0.95     8-15 nulls, 0.66-0.84 ->  1 null, 0.98
 
+  One-chunk leak, k+1 tokens in a single update(), stop inside the reasoning
+  tail of the same chunk that closes:
+                                        fires the stop        ->  does not fire
+  controls: stop present in CONTENT     fires                 ->  fires
+            chunk without the marker    dormant               ->  dormant
+
   The residual single null is mechanism (B) in issue #18 (marginal-stability
   runaway), which this patch does not address and does not claim to.
 
+INTERACTION WITH #18 (B)
+  If `</think>` never arrives -- which is exactly what (B) does -- stops stay
+  dormant for the whole request, so a runaway now runs to max_tokens where a
+  client stop string might previously have cut it short by accident. That is
+  correct by design (the stop was never meant to bound reasoning) but it means
+  (B) becomes MORE visible after this patch, not less. Do not read that as a
+  regression.
+
 APPLIES TO
-  vLLM 0.21.1rc1.dev339+g1967a5627bc3, as shipped in
-  vllm-dspark-runtime:dspark-nvfp4-stage-c.
+  vLLM build 0.21.1rc1.dev339+g1967a5627bc3 (keyed on the build string rather
+  than an image tag: verified on vllm-dspark-runtime:dspark-nvfp4-stage-c and,
+  per @tonyd2wild, on mia-raf-pr1-nvfp4-probe-c-keys-concurrency-p2b).
   If `patch` rejects a hunk, the runtime moved -- regenerate rather than force.
 
 TWO-NODE NOTE
@@ -48,7 +79,14 @@ DOGFOOD
 
 --- a/vllm/v1/engine/detokenizer.py
 +++ b/vllm/v1/engine/detokenizer.py
-@@ -59,10 +59,31 @@
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import os
+ from abc import ABC, abstractmethod
+ 
+ import tokenizers
+@@ -59,10 +60,61 @@
  
          if USE_FAST_DETOKENIZER and isinstance(tokenizer, PreTrainedTokenizerFast):
              # Fast tokenizer => use tokenizers library DecodeStream.
@@ -66,9 +104,34 @@ DOGFOOD
 +        return detok
 +
 +    @staticmethod
++    def _reasoning_markers() -> tuple[str, str]:
++        # PATCH(stop-in-reasoning): prefer the deployment's own
++        # --reasoning-config over hardcoded markers, so the guard is general
++        # rather than DeepSeek-specific. Falls back to the common defaults.
++        start, end = "<think>", "</think>"
++        try:
++            from vllm.config import get_current_vllm_config_or_none
++
++            cfg = get_current_vllm_config_or_none()
++            rc = getattr(cfg, "reasoning_config", None) if cfg else None
++            if rc is not None:
++                start = getattr(rc, "reasoning_start_str", "") or start
++                end = getattr(rc, "reasoning_end_str", "") or end
++        except Exception as e:
++            logger.debug(
++                "stop-in-reasoning: no reasoning config (%s); using %r / %r",
++                e,
++                start,
++                end,
++            )
++        return start, end
++
++    @staticmethod
 +    def _maybe_enable_reasoning_guard(detok, tokenizer, request) -> None:
 +        # PATCH(stop-in-reasoning): see BaseIncrementalDetokenizer.__init__.
-+        import os
++        # NOTE: this opt-out is process-wide, not per-request. A caller who
++        # deliberately wants to bound reasoning with a stop string has no
++        # escape hatch short of restarting with it set to 0.
 +        if os.environ.get("VLLM_SUPPRESS_STOPS_IN_REASONING", "1") == "0":
 +            return
 +        try:
@@ -76,38 +139,52 @@ DOGFOOD
 +            ptids = getattr(request, "prompt_token_ids", None)
 +            if not stop or not ptids:
 +                return
-+            think_id = tokenizer.convert_tokens_to_ids("<think>")
++            start_str, end_str = IncrementalDetokenizer._reasoning_markers()
++            think_id = tokenizer.convert_tokens_to_ids(start_str)
 +            if think_id is not None and think_id >= 0 and ptids[-1] == think_id:
 +                detok._reasoning_stop_guard = True
-+        except Exception:
-+            pass
++                detok._reasoning_end_str = end_str
++        except Exception as e:
++            # Never swallow silently: a renamed attribute would turn this fix
++            # into a no-op, and that failure mode looks exactly like "the
++            # patch is not installed".
++            logger.debug("stop-in-reasoning: guard not armed (%s)", e)
  
  
  class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
-@@ -89,6 +110,15 @@
+@@ -89,6 +141,16 @@
              self.stop_buffer_length = 0
          self._last_output_text_offset: int = 0
  
 +        # PATCH(stop-in-reasoning): when the prompt ends with the reasoning
-+        # opening token (prompt-side <think>, as DeepSeek-V4/Qwen3 templates do),
-+        # client stop strings must not match inside the reasoning segment --
-+        # matching there truncates mid-think and yields content=None. Stops are
-+        # suppressed until '</think>' appears in the output. Disable with
-+        # VLLM_SUPPRESS_STOPS_IN_REASONING=0.
++        # opening token (prompt-side <think>, as DeepSeek-V4/Qwen3 templates
++        # do), client stop strings must not match inside the reasoning segment
++        # -- matching there truncates mid-think and yields content=None. Stops
++        # stay dormant until the reasoning end marker appears in the output.
++        # Disable with VLLM_SUPPRESS_STOPS_IN_REASONING=0 (process-wide).
 +        self._reasoning_stop_guard: bool = False
 +        self._reasoning_closed: bool = False
++        self._reasoning_end_str: str = "</think>"
 +
          # Generation data
          self.output_text = ""
  
-@@ -126,8 +156,16 @@
+@@ -126,8 +188,24 @@
              self.token_ids.append(skipped_stop_token_id)
  
          # 2) Evaluate stop strings.
 +        # PATCH(stop-in-reasoning): keep stops dormant while reasoning is open.
 +        if self._reasoning_stop_guard and not self._reasoning_closed:
-+            if "</think>" in self.output_text[max(0, stop_check_offset - 16):]:
++            marker = self._reasoning_end_str
++            window = max(0, stop_check_offset - (len(marker) - 1))
++            idx = self.output_text.find(marker, window)
++            if idx != -1:
 +                self._reasoning_closed = True
++                # Only evaluate stops over what FOLLOWS the marker. With
++                # speculative decoding this same update() carries up to k+1
++                # tokens, so the reasoning that preceded the close arrives in
++                # this very chunk and must not be able to fire a stop.
++                stop_check_offset = max(stop_check_offset, idx + len(marker))
          stop_string = None
 -        if self.stop and self.num_output_tokens() > self.min_tokens:
 +        if (

--- a/patches/0005-suppress-stops-in-reasoning.patch
+++ b/patches/0005-suppress-stops-in-reasoning.patch
@@ -1,0 +1,120 @@
+From: Capicua25x
+Subject: [PATCH 0005] detokenizer: don't evaluate client stop strings inside the
+ reasoning segment
+
+Fixes null/empty content on think-in-prompt models when the client sends stop
+strings. See issue #18.
+
+WHY
+  vLLM's v1 detokenizer checks client `stop` strings against the whole output
+  stream. With think-in-prompt templates (DeepSeek V4, Qwen3) generation begins
+  INSIDE the reasoning segment, and chain-of-thought naturally restates phrases
+  like "Question:". Any harness that sends stop sequences -- lm-evaluation-harness
+  sends stop[:4] on every request -- decapitates the reasoning mid-<think>.
+  `</think>` never arrives, so the reasoning parser yields content = null.
+
+  Hosted reference deployments of the same checkpoints are immune because they
+  scope stop strings to content. That behaviour gap is the bug.
+
+WHAT
+  Per-request guard, no configuration required: at detokenizer construction, if
+  the request's LAST PROMPT TOKEN is `<think>`, stop strings stay dormant until
+  `</think>` appears in the output. EOS and max_tokens are unaffected.
+  Non-thinking requests are untouched by construction.
+  Opt-out: VLLM_SUPPRESS_STOPS_IN_REASONING=0
+
+MEASURED (2x DGX Spark GB10, TP=2, k=5 profile, unsloth/DeepSeek-V4-Flash-0731)
+  decapitation reproducer (seed+stop)   43 tok, content null  ->  344 tok, correct
+  stop honored on non-thinking request  ok                    ->  ok (exact cut)
+  GSM8K n=50, temp 0.6 / top_p 0.95     8-15 nulls, 0.66-0.84 ->  1 null, 0.98
+
+  The residual single null is mechanism (B) in issue #18 (marginal-stability
+  runaway), which this patch does not address and does not claim to.
+
+APPLIES TO
+  vLLM 0.21.1rc1.dev339+g1967a5627bc3, as shipped in
+  vllm-dspark-runtime:dspark-nvfp4-stage-c.
+  If `patch` rejects a hunk, the runtime moved -- regenerate rather than force.
+
+TWO-NODE NOTE
+  start-deepseek-v4-flash-dspark.sh syncs the compose and env files to the
+  worker, but NOT bind-mounted patch files. This file must exist at the same
+  path on BOTH nodes or the worker silently runs unpatched, which produces
+  confusing half-fixed results.
+
+DOGFOOD
+  Deployed 2026-08-05, run under real agent traffic for four days before
+  submitting. No stop-decapitation observed since.
+
+--- a/vllm/v1/engine/detokenizer.py
++++ b/vllm/v1/engine/detokenizer.py
+@@ -59,10 +59,31 @@
+ 
+         if USE_FAST_DETOKENIZER and isinstance(tokenizer, PreTrainedTokenizerFast):
+             # Fast tokenizer => use tokenizers library DecodeStream.
+-            return FastIncrementalDetokenizer(tokenizer, request)
+-
+-        # Fall back to slow python-based incremental detokenization.
+-        return SlowIncrementalDetokenizer(tokenizer, request)
++            detok = FastIncrementalDetokenizer(tokenizer, request)
++        else:
++            # Fall back to slow python-based incremental detokenization.
++            detok = SlowIncrementalDetokenizer(tokenizer, request)
++        IncrementalDetokenizer._maybe_enable_reasoning_guard(
++            detok, tokenizer, request
++        )
++        return detok
++
++    @staticmethod
++    def _maybe_enable_reasoning_guard(detok, tokenizer, request) -> None:
++        # PATCH(stop-in-reasoning): see BaseIncrementalDetokenizer.__init__.
++        import os
++        if os.environ.get("VLLM_SUPPRESS_STOPS_IN_REASONING", "1") == "0":
++            return
++        try:
++            stop = getattr(detok, "stop", None)
++            ptids = getattr(request, "prompt_token_ids", None)
++            if not stop or not ptids:
++                return
++            think_id = tokenizer.convert_tokens_to_ids("<think>")
++            if think_id is not None and think_id >= 0 and ptids[-1] == think_id:
++                detok._reasoning_stop_guard = True
++        except Exception:
++            pass
+ 
+ 
+ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
+@@ -89,6 +110,15 @@
+             self.stop_buffer_length = 0
+         self._last_output_text_offset: int = 0
+ 
++        # PATCH(stop-in-reasoning): when the prompt ends with the reasoning
++        # opening token (prompt-side <think>, as DeepSeek-V4/Qwen3 templates do),
++        # client stop strings must not match inside the reasoning segment --
++        # matching there truncates mid-think and yields content=None. Stops are
++        # suppressed until '</think>' appears in the output. Disable with
++        # VLLM_SUPPRESS_STOPS_IN_REASONING=0.
++        self._reasoning_stop_guard: bool = False
++        self._reasoning_closed: bool = False
++
+         # Generation data
+         self.output_text = ""
+ 
+@@ -126,8 +156,16 @@
+             self.token_ids.append(skipped_stop_token_id)
+ 
+         # 2) Evaluate stop strings.
++        # PATCH(stop-in-reasoning): keep stops dormant while reasoning is open.
++        if self._reasoning_stop_guard and not self._reasoning_closed:
++            if "</think>" in self.output_text[max(0, stop_check_offset - 16):]:
++                self._reasoning_closed = True
+         stop_string = None
+-        if self.stop and self.num_output_tokens() > self.min_tokens:
++        if (
++            self.stop
++            and self.num_output_tokens() > self.min_tokens
++            and (not self._reasoning_stop_guard or self._reasoning_closed)
++        ):
+             stop = check_stop_strings(
+                 output_text=self.output_text,
+                 new_char_count=len(self.output_text) - stop_check_offset,


### PR DESCRIPTION
**Patch 5: don't evaluate client stop strings inside the reasoning segment**

With think-in-prompt templates generation begins inside `<think>`, and CoT restates
phrases like `Question:`. Any harness sending stop sequences — lm-eval sends
`stop[:4]` on every request — decapitates the reasoning: `</think>` never arrives
and the parser returns `content: null`. It looks like a model failure and is a
serving one.

Per-request guard, no config. If the last prompt token is `<think>`, stops stay
dormant until `</think>`. EOS and `max_tokens` unaffected, non-thinking requests
untouched. Opt-out via `VLLM_SUPPRESS_STOPS_IN_REASONING=0`.

GSM8K n=50, temp 0.6: **8–15 nulls / 0.66–0.84 → 1 null / 0.98**. The residual
null is mechanism (B) of #18 and out of scope here.

Dogfooded four days under real agent traffic before submitting.
