### PR TITLE
Fix four recipe defects surfaced by issues #6, #8 and #16

### DIFF
--- a/DSPARK-SHARED-EXPERT-FIX.md
+++ b/DSPARK-SHARED-EXPERT-FIX.md
@@ -231,8 +231,10 @@ Two things previously documented here were wrong, and are fixed in this revision
 
 2. **The divisibility rule was stated imprecisely.** The guard only fires when
    `k > n_predict`, which is why `k=3` and `k=4` boot fine. The accurate rule is: **`k ≤ 5`, or a
-   multiple of 5.** Note upstream vLLM uses a `>=` check for DSpark instead, so upstream permits
-   `k=7` at config time — and then hits the same tensor-shape crash.
+   multiple of 5.** Upstream 0.25.2 uses the **same** `>` check, but resolves `n_predict` to
+   `num_nextn_predict_layers` (1 for this checkpoint) rather than `dspark_block_size`, so the
+   guard never fires there; and its DSpark speculator sizes the draft block from `k`, so no shape
+   mismatch follows. See issue #22.
 
 Where k=7 *does* work is on drafters whose draft block is at least 7 — e.g. MiMo-V2.5 DFlash
 (`block_size` = 8, run here at `num_speculative_tokens: 7`), GLM-5.2's DSpark speculator

--- a/README.md
+++ b/README.md
@@ -99,13 +99,29 @@ therefore measures **steps/s, not tokens/s**, and under-reports by the acceptanc
 vs 60.1 tok/s on the identical request. Read `usage.completion_tokens`, or divide server-side
 `vllm:generation_tokens_total` by wall time.
 
-**`k` is still 5.** `dspark_block_size = 5` in the 0731 checkpoint exactly as in the preview.
-DeepSeek's 0731 model card recommends `num_speculative_tokens: 7`; that does not work here. The
-boot-time divisibility guard can be patched out, but the run then fails on first generation
-because the drafter emits exactly `dspark_block_size` tokens per pass and multi-block drafting is
-not implemented — the same reason `k=10` boots and then crashes. `k=7` is fine on drafters that
-are natively deeper (MiMo-V2.5 DFlash, GLM-5.2's DSpark speculator, Inkling); DeepSeek-V4-Flash is
-not one of them.
+**`k` is still 5 on this runtime — and that is a property of the runtime, not the checkpoint.**
+`dspark_block_size = 5` in the 0731 checkpoint exactly as in the preview, and DeepSeek's model
+card recommends `num_speculative_tokens: 7`.
+
+On **this recipe's image** (vLLM `0.21.1rc1.dev339+g1967a5627bc3` + B12X), k=7 does not work.
+`SpeculativeConfig.hf_config_override` has a DSpark branch that sets `n_predict =
+dspark_block_size = 5`, so the divisibility guard rejects it at boot. Patch that guard out and the
+run crashes on the first generation with `The size of tensor a (7) must match the size of tensor b
+(5)` — the draft model hardcodes its block width to `dspark_block_size`, so `propose()` returns 5
+columns however large `k` is. `k=10` fails the same way. The accurate rule **on this image** is
+`k <= 5`, or a multiple of 5.
+
+On the **anemll 0.25.2 lineage** (`ghcr.io/anemll/dspark-vllm-gx10:0.1.1`, vLLM
+`0.25.2.dev0+g752a3a504`) neither failure occurs. That build has no DSpark branch in
+`hf_config_override`, so `n_predict` resolves to `num_nextn_predict_layers` = **1** and the guard
+is inert; and its `DSparkSpeculator` sizes the draft block from `num_speculative_tokens` rather
+than `dspark_block_size`, so a 7-wide draft is simply a wider single block. k=7 boots and
+generates there — confirmed by @robotnurse in #22 with per-position acceptance for positions 0-6.
+Corollary on that image: omit `num_speculative_tokens` and you get k=1, not k=5.
+
+Deeper drafts are still not the missing speed on either runtime: positions 4-5 accept at
+0.078/0.047 on hard content here, and #22 measured k=5 → k=7 buying +3.3% tokens/step for a 33%
+wider verify batch.
 
 ### Ruled out by measurement, so you don't repeat it
 
@@ -385,6 +401,45 @@ Capture runtime evidence before and after any fix:
 scripts/capture_runtime.sh runtime-before-change
 scripts/capture_runtime.sh runtime-after-change
 ```
+
+## ⚠️ On `nvfp4_ds_mla` — read this before quoting the KV numbers
+
+**On DeepSeek V4, `nvfp4_ds_mla` and `fp8_ds_mla` currently allocate the identical KV envelope.**
+Verified by reading the runtime in this recipe's own image:
+
+```python
+# vllm/models/deepseek_v4/nvidia/flashmla.py:106
+if cache_dtype_str == "nvfp4_ds_mla":
+    # Stage C: DeepSeek V4 padded NVFP4 probe. Match the fp8_ds_mla
+    # envelope first; if this boots, kernel/store correctness is next.
+    return (num_blocks, block_size, 584)
+if cache_dtype_str == "fp8_ds_mla":
+    return (num_blocks, block_size, 584)
+
+# vllm/v1/kv_cache_interface.py:357  (real_page_size_bytes)
+if self.cache_dtype_str == "nvfp4_ds_mla":
+    if self.model_version == "deepseek_v4":
+        return self.storage_block_size * 584     # same as fp8
+    return self.storage_block_size * 416         # the real NVFP4 path — V3.2 only
+```
+
+Both are **584 bytes per token** on V4. The genuine 416-byte NVFP4 layout exists but only applies
+to V3.2. The server says so itself at boot: `Using probe DeepSeek V4 nvfp4_ds_mla KV cache format.`
+
+What this means in practice:
+
+- **The KV-pool figures in this repo are fp8-sized budgets.** Selecting `nvfp4_ds_mla` on V4 does
+  not buy extra context over `fp8_ds_mla`; the two are the same allocation.
+- It explains why every `fp8_ds_mla` vs `nvfp4_ds_mla` A/B in this repo measured identically on
+  throughput and draft acceptance — they are the same code path on this model.
+- **The repo name overstates this.** It predates the V4 port, when the 416-byte path was live.
+
+What has *not* been established: whether the CuTeDSL attention kernels perform genuine 4-bit
+compute inside that envelope. We only audited the allocation and page-size path, not the kernels.
+So treat this as "the pool is fp8-sized" — not as "NVFP4 does nothing."
+
+Tracking this properly rather than quietly editing the numbers. If you have been sizing context
+budgets off the NVFP4 claim, size them off the `fp8_ds_mla` figures instead.
 
 ## Reasoning / thinking mode
 

--- a/README.md
+++ b/README.md
@@ -386,6 +386,51 @@ scripts/capture_runtime.sh runtime-before-change
 scripts/capture_runtime.sh runtime-after-change
 ```
 
+## Reasoning / thinking mode
+
+Reasoning is **off by default** in this recipe (`--default-chat-template-kwargs '{"thinking":false}'`).
+Everything below was measured on this stack; several of these have cost people real time.
+
+**The response field is `reasoning`, not `reasoning_content`.**
+Non-streaming: `choices[0].message.reasoning`. Streaming: `choices[0].delta.reasoning`.
+There is **no** `reasoning_content` key in a response on this runtime — it is deprecated and only
+accepted on *input*. Clients reading `reasoning_content` see empty and conclude reasoning
+extraction is broken. Credit @vinicius-symetrix (PR #13) for independently reporting the
+streaming half of this.
+
+**`<think>` is written into the prompt, not generated.**
+
+```
+thinking off →  ...<｜Assistant｜></think>
+thinking on  →  ...<｜Assistant｜><think>
+```
+
+So in thinking mode the model's output *starts* with reasoning text and ends with `</think>`;
+there is no opening tag in the completion. **A missing `<think>` in the output is correct
+behaviour.** If you see `</think>` inside `content`, your server is missing
+`--reasoning-parser deepseek_v4` and `--reasoning-config`.
+
+**Enabling it.** Per request: `chat_template_kwargs: {"thinking": true}`, or a top-level
+`reasoning_effort` of `low`/`high`/`max`. Server-wide:
+`--default-chat-template-kwargs '{"thinking":true}'`.
+
+**Never send `reasoning_effort: "none"` together with `thinking: true`.** `"none"` forces
+chat-mode formatting while the reasoning parser stays armed for thinking; with no `</think>`
+in the output the parser puts the *entire* response into `reasoning` and returns
+`content: null`. Measured 4/4 — real `completion_tokens`, `finish_reason: stop`, empty content.
+`reasoning_effort` on its own is fine.
+
+**`reasoning_effort: "low"` behaves as `"high"` on the stock build** — only `"max"`/`"xhigh"`
+differ. See PR #17.
+
+**With `--tokenizer-mode deepseek_v4`, a `chat_template.jinja` in the model directory is
+ignored** — prompt formatting comes from the checkpoint's built-in encoder, not a Jinja
+template. This is why the HuggingFace discussion #26 workaround has no effect here.
+
+**Thinking mode needs output budget.** Reasoning consumes `max_tokens` before any content is
+produced, so a small cap yields `finish_reason: length` with empty `content`. If you benchmark
+thinking mode at a low cap you will measure truncation, not the model.
+
 ## Benchmarks
 
 ### 2026-07-29 full re-characterisation (authoritative — start here)

--- a/README.md
+++ b/README.md
@@ -402,45 +402,6 @@ scripts/capture_runtime.sh runtime-before-change
 scripts/capture_runtime.sh runtime-after-change
 ```
 
-## ⚠️ On `nvfp4_ds_mla` — read this before quoting the KV numbers
-
-**On DeepSeek V4, `nvfp4_ds_mla` and `fp8_ds_mla` currently allocate the identical KV envelope.**
-Verified by reading the runtime in this recipe's own image:
-
-```python
-# vllm/models/deepseek_v4/nvidia/flashmla.py:106
-if cache_dtype_str == "nvfp4_ds_mla":
-    # Stage C: DeepSeek V4 padded NVFP4 probe. Match the fp8_ds_mla
-    # envelope first; if this boots, kernel/store correctness is next.
-    return (num_blocks, block_size, 584)
-if cache_dtype_str == "fp8_ds_mla":
-    return (num_blocks, block_size, 584)
-
-# vllm/v1/kv_cache_interface.py:357  (real_page_size_bytes)
-if self.cache_dtype_str == "nvfp4_ds_mla":
-    if self.model_version == "deepseek_v4":
-        return self.storage_block_size * 584     # same as fp8
-    return self.storage_block_size * 416         # the real NVFP4 path — V3.2 only
-```
-
-Both are **584 bytes per token** on V4. The genuine 416-byte NVFP4 layout exists but only applies
-to V3.2. The server says so itself at boot: `Using probe DeepSeek V4 nvfp4_ds_mla KV cache format.`
-
-What this means in practice:
-
-- **The KV-pool figures in this repo are fp8-sized budgets.** Selecting `nvfp4_ds_mla` on V4 does
-  not buy extra context over `fp8_ds_mla`; the two are the same allocation.
-- It explains why every `fp8_ds_mla` vs `nvfp4_ds_mla` A/B in this repo measured identically on
-  throughput and draft acceptance — they are the same code path on this model.
-- **The repo name overstates this.** It predates the V4 port, when the 416-byte path was live.
-
-What has *not* been established: whether the CuTeDSL attention kernels perform genuine 4-bit
-compute inside that envelope. We only audited the allocation and page-size path, not the kernels.
-So treat this as "the pool is fp8-sized" — not as "NVFP4 does nothing."
-
-Tracking this properly rather than quietly editing the numbers. If you have been sizing context
-budgets off the NVFP4 claim, size them off the `fp8_ds_mla` figures instead.
-
 ## Reasoning / thinking mode
 
 Reasoning is **off by default** in this recipe (`--default-chat-template-kwargs '{"thinking":false}'`).

--- a/benchmarks/garble_tap.py
+++ b/benchmarks/garble_tap.py
@@ -131,7 +131,7 @@ class Handler(BaseHTTPRequestHandler):
                             ch = j.get("choices", [{}])[0]
                             delta = ch.get("delta") or {}
                             collected += (delta.get("content") or "")
-                            collected += (delta.get("reasoning_content") or "")
+                            collected += (delta.get("reasoning") or delta.get("reasoning_content") or "")
                         except Exception:
                             pass
             self.wfile.write(b"0\r\n\r\n")
@@ -145,8 +145,9 @@ class Handler(BaseHTTPRequestHandler):
                 ch = j.get("choices", [{}])[0]
                 msg = ch.get("message") or {}
                 collected = (msg.get("content") or "")
-                if msg.get("reasoning_content"):
-                    collected += msg["reasoning_content"]
+                reasoning = msg.get("reasoning") or msg.get("reasoning_content")
+                if reasoning:
+                    collected += reasoning
                 if msg.get("tool_calls"):
                     collected += json.dumps(msg["tool_calls"])
                 n_out = (j.get("usage") or {}).get("completion_tokens", 0)

--- a/benchmarks/soak.py
+++ b/benchmarks/soak.py
@@ -92,8 +92,12 @@ def worker(wid):
             dt = time.time() - t0
             msg = r["choices"][0]["message"]
             text = (msg.get("content") or "")
-            if msg.get("reasoning_content"):
-                text += msg["reasoning_content"]
+            # This runtime returns reasoning in `reasoning`; `reasoning_content` is
+            # deprecated and only accepted on input. Reading only the old name makes
+            # every thinking-mode response look empty. Keep the fallback for other runtimes.
+            reasoning = msg.get("reasoning") or msg.get("reasoning_content")
+            if reasoning:
+                text += reasoning
             if msg.get("tool_calls"):
                 text += json.dumps(msg["tool_calls"])
             ntok = r["usage"]["completion_tokens"]

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -3,6 +3,7 @@ services:
     image: ${DSPARK_VLLM_IMAGE:-vllm-dspark-runtime:dspark-nvfp4-stage-c}
     network_mode: host
     ipc: host
+    restart: unless-stopped
     shm_size: "64gb"
 
     ulimits:
@@ -123,7 +124,6 @@ services:
         --max-model-len ${MAX_MODEL_LEN:-1048576}
         --max-num-seqs ${MAX_NUM_SEQS:-6}
         --max-num-batched-tokens ${MAX_NUM_BATCHED_TOKENS:-8192}
-        --max-cudagraph-capture-size $$(( ${MAX_NUM_SEQS:-6} * (${MTP_NUM_TOKENS:-5} + 1) ))
         --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION:-0.80}
         --enable-prefix-caching
         --async-scheduling


### PR DESCRIPTION
Four verified defects, each traced to a specific issue thread. No behaviour change beyond what is described.

**1. `docker-compose.dspark.yml`: remove `--max-cudagraph-capture-size`** (issue #8)
`DEFAULT-CONFIG.md:87` says leave it unset; the compose still computed `MAX_NUM_SEQS × (MTP_NUM_TOKENS + 1)`. At `MAX_NUM_SEQS=1` that yields **6** — the exact value that logged `Truncating max_cudagraph_capture_size to 4` in @frankfurth's report, seven minutes before his worker died. Invisible at the shipped defaults (6 × 6 = 36), which is why it survived.

**2. `docker-compose.dspark.yml`: add `restart: unless-stopped`** (issue #8)
Promised in that thread, never landed. The container exits 0 on `EngineDeadError`, so nothing restarts it.

**3. `benchmarks/soak.py`, `benchmarks/garble_tap.py`: read `reasoning`** (issues #6, #16)
This runtime returns `message.reasoning` / `delta.reasoning`. `reasoning_content` is deprecated and accepted only on input — there is no such key in a response. Both harnesses read only the old name, so any thinking-on run emits false `EMPTY`/`SHORT-BODY` events and `garble_tap`'s streaming path drops reasoning entirely. Now prefers `reasoning` with a fallback. Does not invalidate the 553-request soak (ran `thinking:false`).

**4. `README.md`: new 'Reasoning / thinking mode' section** (issue #16)
The repo documented none of this. Covers the field name, that `<think>` is written into the *prompt* so a missing opening tag is correct behaviour, that `reasoning_effort:"none"` + `thinking:true` returns `content: null` (measured 4/4 — a false-positive generator for #6), that `low` behaves as `high` on the stock build, that `chat_template.jinja` is ignored under `--tokenizer-mode deepseek_v4`, and that thinking mode needs output budget.

Opened as a PR rather than pushed to main so the wording can be reviewed.