### PR TITLE
Issue sweep: GHCR workflow, node-local JIT caches, check-patch3 portability, reasoning_effort correction

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -29,6 +29,15 @@ HF_CACHE=${HOME}/.cache/huggingface
 # Optional worker-local Hugging Face cache. Use this when the worker user/path
 # differs from the head node. If blank, the worker uses HF_CACHE.
 WORKER_HF_CACHE=
+# JIT / compile caches. MUST BE NODE-LOCAL on every node — never NFS, and never
+# inside a shared HF_CACHE. Sharing it makes both ranks JIT into the same
+# directories and you get, in order: a torch.compile makedirs race, DeepGEMM
+# "runtime != nullptr" from half-written cubins, and an ABI-mismatched
+# FlashInfer sampling.so built by one node and silently loaded by the other
+# (silent because FLASHINFER_DISABLE_VERSION_CHECK=1). None of the errors name
+# the cache. Credit @antoniohlc, issue #27. Default is node-local already;
+# only set this if you keep HF_CACHE on NFS and want the JIT tree elsewhere.
+#JIT_CACHE_DIR=${HOME}/.cache/vllm-dspark
 HF_HUB_OFFLINE=0
 TRANSFORMERS_OFFLINE=0
 HF_HUB_DISABLE_XET=1
@@ -120,6 +129,10 @@ VLLM_DSV4_DSPARK_DEFER_TARGET_CAPTURE_EXACT=0
 #   AUTO so it selects the DeepSeek-V4 sparse MLA path that works with nvfp4_ds_mla.
 
 # Runtime defaults.
+# Engine-ready timeout. Stock 600 s trips torch.distributed teardown on a warm
+# restart of this 155 GiB two-node load; the second startup dies with no useful
+# error. 3600 matches the sparkrun profile (PR #19).
+VLLM_ENGINE_READY_TIMEOUT_S=3600
 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
 VLLM_TRITON_MLA_SPARSE=1
 VLLM_SPARSE_INDEXER_MAX_LOGITS_MB=256

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,196 @@
+name: Publish runtime image to GHCR
+
+# Publishes the exact vLLM runtime this repo's benchmarks are measured on, so
+# the numbers here point at a pullable image instead of "build it yourself".
+#
+# WHY THIS NEEDS A SELF-HOSTED RUNNER
+# -----------------------------------
+# The image is arm64/GB10 only (sm_121, TORCH_CUDA_ARCH_LIST=12.1a) and roughly
+# 19 GB. GitHub's hosted runners are x86-64, so they cannot build it, and QEMU
+# emulation of a CUDA toolchain build is not a realistic path. The build must
+# therefore happen on a DGX Spark behind a self-hosted runner labelled
+# `[self-hosted, linux, ARM64, dgx-spark]`.
+#
+# The runner also needs the local base image `vllm-dspark-runtime:mia-raf-pr1`
+# already present in its Docker daemon: build-dspark-vllm-runtime.sh starts from
+# it and it is not published anywhere. `verify-base` below fails fast with that
+# message rather than letting the build die 20 minutes in.
+#
+# AUTH
+# ----
+# No PAT and no `write:packages` on any personal account. `permissions.packages:
+# write` grants the automatic GITHUB_TOKEN exactly the scope needed to push to
+# ghcr.io/<owner>/<package>. That is the whole credential story; earlier claims
+# in issue #12 that this was blocked on a token were wrong.
+#
+# TRIGGERS
+# --------
+#   release: published   — the normal path; the release tag names the image tag
+#   push: tags 'v*'      — same thing without a release object
+#   workflow_dispatch    — manual, with an explicit tag, for re-publishing
+#
+# TAGS PUSHED
+#   ghcr.io/<owner>/vllm-dspark-runtime:<version>          (e.g. v2026.08.12)
+#   ghcr.io/<owner>/vllm-dspark-runtime:sha-<short-sha>    (immutable coordinate)
+#   ghcr.io/<owner>/vllm-dspark-runtime:latest             (unless prerelease)
+#
+# The sha- tag is the one to cite in benchmark docs: a version tag can be moved,
+# a commit cannot.
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to publish (e.g. v2026.08.12)'
+        required: true
+        type: string
+      publish_latest:
+        description: 'Also move the :latest tag'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-ghcr
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: vllm-dspark-runtime
+  # Local build tags produced by build-dspark-vllm-runtime.sh.
+  DSPARK_BASE_IMAGE: vllm-dspark-runtime:mia-raf-pr1
+  DSPARK_VLLM_IMAGE: vllm-dspark-runtime:dspark-nvfp4-stage-c
+
+jobs:
+  publish:
+    # The Spark that carries the arm64 base image. Register it with:
+    #   ./config.sh --labels self-hosted,linux,ARM64,dgx-spark
+    runs-on: [self-hosted, linux, ARM64, dgx-spark]
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out the recipe
+        uses: actions/checkout@v4
+
+      - name: Resolve the version tag
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version='${{ inputs.image_tag }}'
+            latest='${{ inputs.publish_latest }}'
+          else
+            version="${GITHUB_REF_NAME}"
+            latest=true
+            if [ "${{ github.event_name }}" = "release" ] && \
+               [ "${{ github.event.release.prerelease }}" = "true" ]; then
+              latest=false
+            fi
+          fi
+          case "$version" in
+            ''|*' '*|*'/'*) echo "::error::refusing to publish tag '$version'"; exit 1 ;;
+          esac
+          # GHCR paths must be lower-case; the owner may not be.
+          owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          echo "version=$version"                                   >> "$GITHUB_OUTPUT"
+          echo "latest=$latest"                                     >> "$GITHUB_OUTPUT"
+          echo "repo=${REGISTRY}/${owner}/${IMAGE_NAME}"            >> "$GITHUB_OUTPUT"
+          echo "sha_tag=sha-$(git rev-parse --short=12 HEAD)"       >> "$GITHUB_OUTPUT"
+
+      - name: Verify the local base image is present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! docker image inspect "$DSPARK_BASE_IMAGE" >/dev/null 2>&1; then
+            echo "::error::base image '$DSPARK_BASE_IMAGE' is not in this runner's"
+            echo "::error::Docker daemon. It is a local image and is not published"
+            echo "::error::anywhere, so this workflow cannot fetch it. Load it on the"
+            echo "::error::runner first, then re-run."
+            exit 1
+          fi
+          docker image inspect "$DSPARK_BASE_IMAGE" \
+            --format 'base image ok: {{.Id}} {{.Architecture}} {{.Os}}'
+
+      - name: Build the runtime (bash, same script humans run)
+        shell: bash
+        env:
+          # Never let the build script rsync/ssh to the peer node from CI.
+          WORKER_BUILD: '0'
+          # Ignore any .env.dspark that happens to sit on the runner.
+          ENV_FILE: /dev/null
+        run: ./build-dspark-vllm-runtime.sh
+
+      - name: Verify the built image before pushing anything
+        shell: bash
+        run: |
+          set -euo pipefail
+          arch="$(docker image inspect "$DSPARK_VLLM_IMAGE" --format '{{.Architecture}}')"
+          [ "$arch" = "arm64" ] || { echo "::error::built $arch, expected arm64"; exit 1; }
+          # Patch 3 and Patch 4 are the two fixes whose absence is invisible until
+          # production (cold-prefill garble; half-speed drafting). Fail closed.
+          docker run --rm --entrypoint bash "$DSPARK_VLLM_IMAGE" -c '
+            set -e
+            R=/opt/env/lib/python3.12/site-packages/vllm
+            grep -q is_prefill_chunk "$R/v1/core/sched/scheduler.py" \
+              || { echo "FATAL: Patch 3 missing"; exit 1; }
+            grep -q shared_experts.gate_up_proj "$R/v1/spec_decode/dspark.py" \
+              || { echo "FATAL: Patch 4 missing"; exit 1; }
+            /opt/env/bin/python -c "import vllm; print(\"vllm\", vllm.__version__)"
+          '
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and push
+        shell: bash
+        env:
+          REPO: ${{ steps.meta.outputs.repo }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          SHA_TAG: ${{ steps.meta.outputs.sha_tag }}
+          PUSH_LATEST: ${{ steps.meta.outputs.latest }}
+        run: |
+          set -euo pipefail
+          for t in "$VERSION" "$SHA_TAG"; do
+            docker tag "$DSPARK_VLLM_IMAGE" "$REPO:$t"
+            docker push "$REPO:$t"
+          done
+          if [ "$PUSH_LATEST" = "true" ]; then
+            docker tag "$DSPARK_VLLM_IMAGE" "$REPO:latest"
+            docker push "$REPO:latest"
+          fi
+
+      - name: Summary
+        shell: bash
+        env:
+          REPO: ${{ steps.meta.outputs.repo }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          SHA_TAG: ${{ steps.meta.outputs.sha_tag }}
+        run: |
+          {
+            echo "### Published"
+            echo
+            echo '```'
+            echo "docker pull $REPO:$VERSION"
+            echo "docker pull $REPO:$SHA_TAG"
+            echo '```'
+            echo
+            echo "Set \`DSPARK_VLLM_IMAGE=$REPO:$VERSION\` in \`.env.dspark\`."
+            echo
+            echo "New packages are **private by default**. Make it public once, at"
+            echo "Packages -> $IMAGE_NAME -> Package settings -> Change visibility,"
+            echo "or anonymous \`docker pull\` will 401."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -491,12 +491,40 @@ in the output the parser puts the *entire* response into `reasoning` and returns
 `content: null`. Measured 4/4 — real `completion_tokens`, `finish_reason: stop`, empty content.
 `reasoning_effort` on its own is fine.
 
-**`reasoning_effort: "low"` behaves as `"high"` on the stock build** — only `"max"`/`"xhigh"`
-differ. See PR #17.
+**`reasoning_effort: "low"`, `"medium"` and `"high"` all produce *no* effort prefix.** They
+normalise to an internal `"high"` that has no injection branch, so nothing is added to the
+prompt. Only `"max"`/`"xhigh"` inject — and what they inject is the model's **high** text
+(79 tokens), not its `max` text (96). **The model's `max` effort is unreachable on this
+tokenizer mode**, and anyone selecting `"high"` here is running at the vendor's *low*.
+
+An earlier revision of this section said `"low"` behaves as `"high"`. That was true of the
+runtime's internal variable and **inverted as advice** — corrected after @Capicua25x measured
+it (issue #25). Verify in three requests; `prompt_tokens` is the whole witness:
+
+```bash
+for E in low high max; do
+  printf '%-5s ' "$E"
+  curl -s http://127.0.0.1:8888/v1/chat/completions -H 'Content-Type: application/json' \
+    -d "{\"model\":\"deepseek-v4-flash-dspark\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],
+         \"max_tokens\":1,\"reasoning_effort\":\"$E\"}" \
+  | python3 -c 'import json,sys; print("prompt_tokens =", json.load(sys.stdin)["usage"]["prompt_tokens"])'
+done
+# this stack:  low 5 | high 5 (identical — no prefix) | max 84 (+79)
+# api.deepseek.com, same messages: low 681 | high 760 (+79) | max 773
+```
+
+PR #24 vendors the checkpoint's own three-level table and restores the distinction. **Note the
+behaviour change when it lands:** `reasoning_effort:"max"` will then inject DeepSeek's real max
+text instead of its high text, so existing callers of `"max"` get a materially stronger
+instruction. `"low"` and omitted stay byte-identical.
 
 **With `--tokenizer-mode deepseek_v4`, a `chat_template.jinja` in the model directory is
 ignored** — prompt formatting comes from the checkpoint's built-in encoder, not a Jinja
-template. This is why the HuggingFace discussion #26 workaround has no effect here.
+template. This is why the HuggingFace discussion #26 workaround has no effect here. It is
+stronger than that: **explicitly passing `--chat-template /path/to/chat_template.jinja` is also
+ignored** — it shows up in the engine's `non-default args` and changes nothing (measured in
+#25). There is no way to reach the template's three-way effort split without leaving
+`tokenizer_mode=deepseek_v4`, which this recipe needs for DSpark.
 
 **Thinking mode needs output budget.** Reasoning consumes `max_tokens` before any content is
 produced, so a small cap yields `finish_reason: length` with empty `content`. If you benchmark
@@ -1101,6 +1129,67 @@ Check ownership before blaming the recipe:
 ls -ld "${HF_CACHE:-$HOME/.cache/huggingface}"
 ```
 
+### Empty `content` with real `completion_tokens` — classify before you report
+
+A bare "null-content rate" now aggregates at least five unrelated causes, and they want
+different fixes. Two fields settle which one you have. Do this before opening an issue or
+quoting a rate:
+
+| `finish_reason` | `</think>` in the raw output | what it is |
+| --- | --- | --- |
+| `stop` | no | a **client stop string fired inside reasoning** — the CoT restated it, generation was decapitated before `</think>`. lm-eval sends `stop[:4]` on every request. Fix: PR #21's reasoning-aware stop guard, or `until: []` client-side. |
+| `length` | no | **budget exceeded**, not a hang. Reasoning is heavy-tailed even on trivial prompts (48–440 tokens measured on `"What's 1 + 1?"`). Raise `max_tokens` and re-measure; if the rate moves with the budget it was never a non-termination. |
+| `length` | no, *and* the rate does not move with budget | **genuine non-termination** — a repetition loop. Detector that works: 3 consecutive 4,000-char windows below 2% novel word-8-grams. Block-level uniqueness reads *high* on plainly looping text; do not use it. Tracked in issue #18 (B). Sampling at the checkpoint's specified `temperature 1.0` measured 18/18 terminating vs 14/36 at 0.6. |
+| `stop` | n/a | you sent **`reasoning_effort:"none"` with `thinking:true`** — chat-mode prompt, thinking-armed parser. See above in *Reasoning / thinking mode*. |
+| `stop` | yes, and the answer is missing at the client only | the client is reading **`reasoning_content`**; the response key is **`reasoning`**. |
+
+A sixth, rarer one: the model occasionally emits a pseudo-tag scaffold
+(`<STORE_AND_RETURN> 570 </STORE_AND_RETURN>`, `<STDERR> final</STDERR>630`) as its *entire*
+output and never closes `</think>`, so the parser files everything as reasoning. Measured
+5/60 → 0/60 with a marker-specific fallback, ~0.8% residual on a different tag; tag-matching is
+whack-a-mole, so this is documented rather than patched. Non-streaming only in the reported
+measurements. Credit @robotnurse (issue #6).
+
+Classifying costs nothing and it is what made issue #18 tractable.
+
+### Sharing the HF cache over NFS between the nodes — seven JIT caches, three failures
+
+**Symptom.** Any of, usually in this order as you fix each one:
+
+* `torch.compile` dies at startup with a `FileExistsError` / `makedirs` race
+* DeepGEMM asserts `runtime != nullptr` — stale or half-written cubins read over NFS
+* the head's first engine attempt dies every boot on an **ABI-mismatched FlashInfer
+  `sampling.so`**, compiled by one node and silently loaded by the other. Silent because this
+  stack runs `FLASHINFER_DISABLE_VERSION_CHECK=1`. With the worker entrypoint not retrying
+  after a process death, this also orphans the worker on each boot.
+
+None of those messages mention the cache. They read like broken kernels or a broken build.
+
+**Cause.** Downloading the 167 GB checkpoint once and serving it to both nodes over NFS is the
+obvious move — but seven JIT/workspace caches default to (or historically sat under) the same
+tree, and then **both ranks JIT into the same directories concurrently**.
+
+**Fix.** `docker-compose.dspark.yml` now mounts a **separate, node-local** volume at
+`/vllm-cache` and points all seven at it, independent of where `HF_CACHE` lives:
+
+| variable | value |
+| --- | --- |
+| `VLLM_CACHE_ROOT` | `/vllm-cache` |
+| `DG_JIT_CACHE_DIR` | `/vllm-cache/deepgemm-cache` |
+| `FLASHINFER_WORKSPACE_BASE` | `/vllm-cache/flashinfer` |
+| `TILELANG_CACHE_DIR` | `/vllm-cache/tilelang` |
+| `TORCHINDUCTOR_CACHE_DIR` | `/vllm-cache/torchinductor-cache` |
+| `TRITON_CACHE_DIR` | `/vllm-cache/triton-cache` |
+| `TORCH_EXTENSIONS_DIR` | `/vllm-cache/torch_extensions` |
+
+The host path is `JIT_CACHE_DIR` (default `${HOME}/.cache/vllm-dspark`) — **keep it on local
+disk on every node**. If you already ran with a shared cache, purge the poisoned directories
+once; a stale `sampling.so` survives the config change.
+
+Credit [@antoniohlc](https://github.com/antoniohlc), issue #27, who found the whole set one
+crash at a time and reproduced this repo's numbers (69.8–73.8 tok/s warm single-stream) once it
+was fixed. The **model weights** in `HF_CACHE` are fine on NFS; it is only the JIT tree that
+must be per-node.
 
 ### Garble fix (2026-07-03)
 

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -28,6 +28,16 @@ services:
       # (HFValidationError: Repo id must be in the form ...).
       - ${LOCAL_MODELS_DIR:-${HF_CACHE:-${HOME}/.cache/huggingface}}:/models:ro
       - ${HF_CACHE:-${HOME}/.cache/huggingface}:/cache/huggingface
+      # NODE-LOCAL JIT/compile caches — deliberately a SEPARATE mount from
+      # HF_CACHE. Seven caches are written concurrently by both ranks; if they
+      # land on a shared (NFS) HF cache the failures are serial and misleading:
+      # a torch.compile makedirs race, DeepGEMM "runtime != nullptr" from
+      # half-written cubins, and — worst — an ABI-mismatched FlashInfer
+      # sampling.so built by one node and silently loaded by the other, silent
+      # because this stack runs FLASHINFER_DISABLE_VERSION_CHECK=1. None of the
+      # error messages point at the cache. Reported by @antoniohlc (issue #27),
+      # who lost a day to it. Keep JIT_CACHE_DIR on local disk on every node.
+      - ${JIT_CACHE_DIR:-${HOME}/.cache/vllm-dspark}:/vllm-cache
       # DSpark source patches are baked into the image from recipe/overlay/
       # (see README "vLLM version note"); do not bind-mount a proposer copy
       # here — a copy from one vLLM version crashes another.
@@ -37,7 +47,21 @@ services:
       HF_HUB_OFFLINE: "${HF_HUB_OFFLINE:-0}"
       TRANSFORMERS_OFFLINE: "${TRANSFORMERS_OFFLINE:-0}"
       HF_HUB_DISABLE_XET: "${HF_HUB_DISABLE_XET:-1}"
-      VLLM_CACHE_ROOT: /cache/huggingface/vllm-cache
+      # All seven JIT/workspace caches point at the node-local /vllm-cache
+      # volume above, NOT at the HF cache tree. See the volume comment and
+      # issue #27 — the set matters, they were found one crash at a time.
+      VLLM_CACHE_ROOT: /vllm-cache
+      DG_JIT_CACHE_DIR: /vllm-cache/deepgemm-cache
+      FLASHINFER_WORKSPACE_BASE: /vllm-cache/flashinfer
+      TILELANG_CACHE_DIR: /vllm-cache/tilelang
+      TORCHINDUCTOR_CACHE_DIR: /vllm-cache/torchinductor-cache
+      TRITON_CACHE_DIR: /vllm-cache/triton-cache
+      TORCH_EXTENSIONS_DIR: /vllm-cache/torch_extensions
+      # Engine-ready timeout. The stock 600 s trips torch.distributed teardown
+      # on a warm restart of this model, which loads 155 GiB across two nodes;
+      # the second startup then dies with no useful error. 3600 matches the
+      # sparkrun profile (PR #19) — this line is the compose-side mirror.
+      VLLM_ENGINE_READY_TIMEOUT_S: "${VLLM_ENGINE_READY_TIMEOUT_S:-3600}"
       # Long-context crash fix kill-switch (see docs/LONG_CONTEXT_CRASH_FIX.md).
       # 1 (default) = clamp stale DSpark draft-KV slot ids; 0 = detect+log only.
       DSPARK_SLOT_CLAMP: "${DSPARK_SLOT_CLAMP:-1}"

--- a/recipe/nvfp4/Dockerfile.stage-a
+++ b/recipe/nvfp4/Dockerfile.stage-a
@@ -1,6 +1,25 @@
 ARG BASE_IMAGE=vllm-dspark-runtime:mia-raf-pr1
 FROM ${BASE_IMAGE}
 
+# CONTRACT — the heredoc delimiters below are load-bearing OUTSIDE Docker.
+#
+# The sparkrun recipe cannot run `docker build`. It rebuilds this stage inside an
+# already-running container by sed-extracting the Python between the quoted-PY
+# heredoc marker on the next line and the lone PY terminator at the end of the
+# file, then piping that to the interpreter — see the `pre_exec` block in
+# sparkrun/deepseek-v4-flash-0731-dspark-nvfp4-1m-vllm.yaml. Consequences:
+#
+#   * keep exactly ONE such heredoc per stage file
+#   * keep the opening marker exactly as written below: quoted, no space
+#   * keep the terminator alone in column 1, no trailing whitespace
+#   * do not add a second heredoc, and do not switch to COPY-a-script
+#   * do not repeat either marker inside this comment — sed matches the FIRST
+#     occurrence, so the extraction would start here instead and hand shell
+#     text to python
+#
+# Changing any of that does not break `docker build`; it breaks sparkrun
+# silently, and it surfaces much later as a missing NVFP4 patch anchor. If the
+# mechanism has to change, change the sparkrun extractor in the same commit.
 RUN /opt/env/bin/python - <<'PY'
 from pathlib import Path
 

--- a/recipe/nvfp4/Dockerfile.stage-b
+++ b/recipe/nvfp4/Dockerfile.stage-b
@@ -1,6 +1,25 @@
 ARG BASE_IMAGE=vllm-dspark-runtime:mia-raf-pr1-nvfp4-a
 FROM ${BASE_IMAGE}
 
+# CONTRACT — the heredoc delimiters below are load-bearing OUTSIDE Docker.
+#
+# The sparkrun recipe cannot run `docker build`. It rebuilds this stage inside an
+# already-running container by sed-extracting the Python between the quoted-PY
+# heredoc marker on the next line and the lone PY terminator at the end of the
+# file, then piping that to the interpreter — see the `pre_exec` block in
+# sparkrun/deepseek-v4-flash-0731-dspark-nvfp4-1m-vllm.yaml. Consequences:
+#
+#   * keep exactly ONE such heredoc per stage file
+#   * keep the opening marker exactly as written below: quoted, no space
+#   * keep the terminator alone in column 1, no trailing whitespace
+#   * do not add a second heredoc, and do not switch to COPY-a-script
+#   * do not repeat either marker inside this comment — sed matches the FIRST
+#     occurrence, so the extraction would start here instead and hand shell
+#     text to python
+#
+# Changing any of that does not break `docker build`; it breaks sparkrun
+# silently, and it surfaces much later as a missing NVFP4 patch anchor. If the
+# mechanism has to change, change the sparkrun extractor in the same commit.
 RUN /opt/env/bin/python - <<'PY'
 from pathlib import Path
 

--- a/recipe/nvfp4/Dockerfile.stage-c
+++ b/recipe/nvfp4/Dockerfile.stage-c
@@ -1,6 +1,25 @@
 ARG BASE_IMAGE=vllm-dspark-runtime:mia-raf-pr1-nvfp4-b
 FROM ${BASE_IMAGE}
 
+# CONTRACT — the heredoc delimiters below are load-bearing OUTSIDE Docker.
+#
+# The sparkrun recipe cannot run `docker build`. It rebuilds this stage inside an
+# already-running container by sed-extracting the Python between the quoted-PY
+# heredoc marker on the next line and the lone PY terminator at the end of the
+# file, then piping that to the interpreter — see the `pre_exec` block in
+# sparkrun/deepseek-v4-flash-0731-dspark-nvfp4-1m-vllm.yaml. Consequences:
+#
+#   * keep exactly ONE such heredoc per stage file
+#   * keep the opening marker exactly as written below: quoted, no space
+#   * keep the terminator alone in column 1, no trailing whitespace
+#   * do not add a second heredoc, and do not switch to COPY-a-script
+#   * do not repeat either marker inside this comment — sed matches the FIRST
+#     occurrence, so the extraction would start here instead and hand shell
+#     text to python
+#
+# Changing any of that does not break `docker build`; it breaks sparkrun
+# silently, and it surfaces much later as a missing NVFP4 patch anchor. If the
+# mechanism has to change, change the sparkrun extractor in the same commit.
 RUN /opt/env/bin/python - <<'PY'
 from pathlib import Path
 

--- a/scripts/check-patch3.sh
+++ b/scripts/check-patch3.sh
@@ -15,11 +15,43 @@
 # exit 0 = Patch 3 present everywhere, exit 1 = missing somewhere.
 set -uo pipefail
 
-SCHED=/opt/env/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py
+# The vLLM package root is NOT the same on every image, and hardcoding it makes
+# this preflight report "No such file" — a FAIL that looks like a missing patch —
+# on a perfectly good deployment. Known layouts:
+#   /opt/env/lib/python3.12/site-packages          this recipe's Stage-C image
+#   /usr/local/lib/python3.12/dist-packages        Debian layout, e.g.
+#                                                  ghcr.io/anemll/dspark-vllm-gx10
+# Reported by @robotnurse in issue #22. Ask Python where vllm actually is, fall
+# back to probing the known paths if no interpreter is on PATH.
+VLLM_ROOT_OVERRIDE="${VLLM_ROOT:-}"
+
+resolve_root() {
+  local c="$1" root=""
+  if [ -n "$VLLM_ROOT_OVERRIDE" ]; then
+    printf '%s\n' "$VLLM_ROOT_OVERRIDE"
+    return 0
+  fi
+  for py in /opt/env/bin/python /usr/local/bin/python3 python3 python; do
+    root=$(docker exec "$c" "$py" -c \
+      'import os,vllm;print(os.path.dirname(vllm.__file__))' 2>/dev/null) || continue
+    [ -n "$root" ] && { printf '%s\n' "$root"; return 0; }
+  done
+  for cand in /opt/env/lib/python3.12/site-packages/vllm \
+              /usr/local/lib/python3.12/dist-packages/vllm \
+              /usr/lib/python3/dist-packages/vllm; do
+    if docker exec "$c" test -d "$cand" 2>/dev/null; then
+      printf '%s\n' "$cand"
+      return 0
+    fi
+  done
+  return 1
+}
+
 rc=0
 
 if [ $# -eq 0 ]; then
   echo "usage: $0 <container-name> [container-name...]" >&2
+  echo "       VLLM_ROOT=/path/to/site-packages/vllm overrides autodetection" >&2
   exit 2
 fi
 
@@ -29,9 +61,22 @@ for c in "$@"; do
     rc=1
     continue
   fi
+  if ! root=$(resolve_root "$c"); then
+    echo "  ?? $c — could not locate the vllm package inside the container."
+    echo "       Re-run with an explicit path, e.g.:"
+    echo "         VLLM_ROOT=/usr/local/lib/python3.12/dist-packages/vllm $0 $c"
+    rc=1
+    continue
+  fi
+  SCHED="$root/v1/core/sched/scheduler.py"
+  if ! docker exec "$c" test -f "$SCHED" 2>/dev/null; then
+    echo "  ?? $c — no scheduler.py at $SCHED (vllm root resolved to $root)"
+    rc=1
+    continue
+  fi
   n=$(docker exec "$c" grep -c is_prefill_chunk "$SCHED" 2>/dev/null || echo 0)
   if [ "${n:-0}" -ge 1 ]; then
-    echo "  OK   $c — Patch 3 present ($n guard references)"
+    echo "  OK   $c — Patch 3 present ($n guard references) at $root"
   else
     echo "  FAIL $c — PATCH 3 MISSING. Cold prefills will garble."
     echo "       Fix on every node:"
@@ -39,6 +84,8 @@ for c in "$@"; do
     echo "       then add to the container run:"
     echo "         -v /var/tmp/patch3-scheduler.py:$SCHED:ro"
     echo "       (or rebuild as dspark-nvfp4-stage-c, which bakes Patch 3 in)"
+    echo "       NOTE: mount to the path printed above, not to a remembered one —"
+    echo "       a bind mount to the wrong path fails SILENTLY."
     rc=1
   fi
 done

--- a/sparkrun/deepseek-v4-flash-0731-dspark-nvfp4-1m-vllm.yaml
+++ b/sparkrun/deepseek-v4-flash-0731-dspark-nvfp4-1m-vllm.yaml
@@ -173,6 +173,17 @@ env:
   VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: "256"
   VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: "0"
   VLLM_SKIP_INIT_MEMORY_CHECK: "1"
+  # WARNING: this assumes /cache/huggingface is NODE-LOCAL. If you share the HF
+  # cache between the two nodes over NFS to avoid downloading 167 GB twice, both
+  # ranks JIT into the same directories and you get, in order: a torch.compile
+  # makedirs race, DeepGEMM "runtime != nullptr" from half-written cubins, and an
+  # ABI-mismatched FlashInfer sampling.so built by one node and silently loaded
+  # by the other (silent because FLASHINFER_DISABLE_VERSION_CHECK=1 below).
+  # In that case override ALL SEVEN onto a node-local path — the set matters:
+  #   VLLM_CACHE_ROOT, DG_JIT_CACHE_DIR, FLASHINFER_WORKSPACE_BASE,
+  #   TILELANG_CACHE_DIR, TORCHINDUCTOR_CACHE_DIR, TRITON_CACHE_DIR,
+  #   TORCH_EXTENSIONS_DIR
+  # See README "Sharing the HF cache over NFS" and issue #27 (@antoniohlc).
   VLLM_CACHE_ROOT: /cache/huggingface/vllm-cache
   HF_HUB_DISABLE_XET: "1"
   # FlashInfer sampler is part of the 2026-07-03 DSpark garble fix.


### PR DESCRIPTION
Five commits, each closing a specific reported gap. No runtime behaviour changes to the serving path.

**1. `.github/workflows/publish-ghcr.yml` (#12)** — the repo had no `.github/` directory at all, which was the actual gap; not a credential problem, as @Archmonger correctly pointed out. Triggers on release/tag/dispatch, `permissions: {packages: write}` with the automatic `GITHUB_TOKEN`, builds via the same `build-dspark-vllm-runtime.sh` humans run. Targets a **self-hosted arm64 runner** — the image is GB10 `sm_121` and ~19 GB, so hosted x86 runners aren't a path. Fails closed pre-push on non-arm64 result, missing Patch 3, or missing Patch 4.

**2. `scripts/check-patch3.sh` portability (#22)** — no longer hardcodes `/opt/env/lib/python3.12/site-packages`. Asks the container's Python where `vllm` lives, falls back to probing known layouts (including `/usr/local/lib/python3.12/dist-packages` on the 0.25.2 lineage), accepts a `VLLM_ROOT` override, and prints the *resolved* path in the remediation hint — a bind mount to the wrong path fails silently.

**3. Node-local JIT caches (#27)** — a new `/vllm-cache` volume (`JIT_CACHE_DIR`, default `~/.cache/vllm-dspark`) with all seven JIT paths pointed at it, independent of `HF_CACHE`. Weights over NFS are fine; the JIT tree must be per-node. The FlashInfer case is why this is a shipped default rather than a doc note: `FLASHINFER_DISABLE_VERSION_CHECK=1` is set here for unrelated reasons and turns a cross-node ABI mismatch into a silent bad load. Also mirrors `VLLM_ENGINE_READY_TIMEOUT_S` into compose so the compose and sparkrun paths don't diverge (owed on #19).

**4. Heredoc contract in `recipe/nvfp4/Dockerfile.stage-*` (#14)** — sparkrun's `pre_exec` reconstructs the overlay by `sed`-ing the heredocs out of these files, so their formatting is load-bearing. Now documented in-file. The comments deliberately never repeat either marker, which would move sparkrun's extraction range; the extractor was re-run against all three stages and produces byte-identical output.

**5. Docs (#25)** — `reasoning_effort` direction corrected per @Capicua25x: `low`/`medium`/`high` inject **no** prefix, only `max`/`xhigh` do, and what they inject is the model's *high* text — so real `max` is unreachable on this tokenizer mode. Verified independently by executing PR #24's vendored table: low 0 / high 476 / max 526 chars, and the 476-char string is byte-identical to the stock build's single `REASONING_EFFORT_MAX`. Also adds the null-content triage table (`finish_reason` × `</think>`-present) and the NFS JIT-cache trap.

Checks: all YAML parses, all shell scripts pass `bash -n`, `check-patch3.sh` exercised against a mock docker across four container layouts with correct exit codes, sparkrun's heredoc extractor verified byte-identical on all three stages, 73 relative markdown links checked.