### PR TITLE
parity: reproducible serving-fidelity bench + frozen hosted reference card

### DIFF
--- a/parity/.gitignore
+++ b/parity/.gitignore
@@ -1,0 +1,1 @@
+parity-results/

--- a/parity/README.md
+++ b/parity/README.md
@@ -1,0 +1,69 @@
+# Parity Bench — verify your deployment actually matches the model
+
+This folder lets any deployment of this recipe answer, in ~1-2 hours of wall clock and
+with hard numbers: **"is my local serving faithful to DeepSeek-V4-Flash-0731, or is my
+stack silently costing me intelligence?"**
+
+## Why this exists
+
+While debugging issue #18 we measured a 25-point GSM8K gap between this stack and a
+hosted deployment of the *identical checkpoint* — caused entirely by serving-layer bugs
+(stop-strings evaluated inside the reasoning segment), not by the model or the hardware.
+After fixing the stack, our 2× GB10 pair matched the hosted reference **exactly**
+(IFEval 0.9375 = 0.9375, first paired benchmark). Deviation from reference = actionable
+serving defect. That is the entire premise.
+
+## The frozen reference card
+
+`reference-card_hosted_v3.json` — DeepSeek-V4-Flash-0731 measured on a professional
+hosted deployment, protocol v3 (`reasoning_effort: max`, temp 0.6 / top_p 0.95, seeds
+1234/2345/3456, lm-eval 0.4.12, fixed item slices):
+
+| Benchmark | Median | Runs |
+|---|---|---|
+| IFEval (80) | **0.938** | 0.900 / 0.938 / 0.938 |
+| MMLU-Pro (80) | **0.837** | 0.826 / 0.837 / 0.841 |
+| GPQA Diamond (60) | **0.733** | 0.667 / 0.733 / 0.767 |
+| AIME 2025 (30) | **0.700** | 0.700 / 0.700 / 0.733 |
+
+You do NOT need to re-buy this card. It is a property of the checkpoint. Your local
+runs compare against it directly.
+
+## Run it
+
+```bash
+pip install "lm-eval[api]" langdetect immutabledict   # once
+./run_parity_bench.sh mybox "http://localhost:8888/v1/chat/completions" ""
+# results land in ./parity-results/<run>/, resumable via .done markers
+```
+
+Three seeds per benchmark; compare your medians to the card. Interpretation:
+
+- **Within the card's run-range** → your serving is faithful. Enjoy.
+- **A benchmark clearly below range** → serving defect. Check the null-content count
+  in the run logs first (`grep -c "null content" *.log`).
+- **High nulls** → truncation (raise `max_gen_toks`) or the stop-string bug (see below).
+
+## Traps this harness already avoids (learned the hard way)
+
+1. **Stop-strings inside reasoning** — think-in-prompt models restate phrases like
+   "Question:" while reasoning; serving stacks that match client stop-strings in the
+   reasoning segment decapitate generation (score craters, e.g. 0.04 on MMLU-Pro).
+   This harness sends `until: []` so it measures correctly on unpatched stacks. We
+   observed this bug on two of three serving stacks tested (issue #18).
+2. **Budget truncation ≠ model failure** — budgets here are sized ~1.6× the observed
+   legit deliberation ceiling per benchmark. Count nulls before blaming the model.
+3. **Runaway-loop tail** — at low temperature this model family can loop verbatim in
+   reasoning (issue #18, mechanism B; reproducers there). Criterion: repeated fragment
+   ≥3×, not budget exhaustion. At temp 0.6 the tail is ~1-2 items per 50 and hits the
+   reference too.
+4. **Single-prompt A/Bs are trajectory noise** — only rates across fixed-seed item
+   sets discriminate. Three seeds minimum; medians with ranges.
+5. **Grouped tasks (MMLU-Pro)** report subtask scores first — read the aggregate key.
+
+## Provenance
+
+Protocol, seeds, and metric keys are embedded in the reference card JSON. Reference
+measured 2026-08-05 via a hosted provider serving the official checkpoint; local
+validation on 2× DGX Spark (GB10) running this recipe at k=5. Full investigation
+narrative: issue #18.

--- a/parity/README.md
+++ b/parity/README.md
@@ -1,7 +1,6 @@
 # Parity Bench — verify your deployment actually matches the model
 
-This folder lets any deployment of this recipe answer, in ~1-2 hours of wall clock and
-with hard numbers: **"is my local serving faithful to DeepSeek-V4-Flash-0731, or is my
+This folder lets any deployment of this recipe answer, with hard numbers: **"is my local serving faithful to DeepSeek-V4-Flash-0731, or is my
 stack silently costing me intelligence?"**
 
 ## Why this exists
@@ -22,9 +21,18 @@ hosted deployment, protocol v3 (`reasoning_effort: max`, temp 0.6 / top_p 0.95, 
 | Benchmark | Median | Runs |
 |---|---|---|
 | IFEval (80) | **0.938** | 0.900 / 0.938 / 0.938 |
-| MMLU-Pro (80) | **0.837** | 0.826 / 0.837 / 0.841 |
+| MMLU-Pro (1120)¹ | **0.837** | 0.826 / 0.837 / 0.841 |
 | GPQA Diamond (60) | **0.733** | 0.667 / 0.733 / 0.767 |
 | AIME 2025 (30) | **0.700** | 0.700 / 0.700 / 0.733 |
+
+¹ `--limit 80` is per-subtask; MMLU-Pro is a 14-subtask group, so n=1120. This also
+sizes the wall clock: the full 3-seed campaign is a **multi-hour / overnight** affair
+at typical local throughput, not a lunch break. GPQA Diamond appears in this table as
+reference context but is not run by the script (the HF dataset is gated and needs
+authenticated access); the machine-readable `parity_targets` list in the card says
+which rows the script reproduces. The card's run-to-run spread reflects server-side
+nondeterminism — the hosted runs' request-level seed was constant (see the card's
+`seed_note`); local runs now pass real per-run seeds.
 
 You do NOT need to re-buy this card. It is a property of the checkpoint. Your local
 runs compare against it directly.
@@ -37,9 +45,13 @@ context, not as parity targets.
 ## Run it
 
 ```bash
-pip install "lm-eval[api]" langdetect immutabledict   # once
-./run_parity_bench.sh mybox "http://localhost:8888/v1/chat/completions" ""
+pip install "lm-eval[api]==0.4.12" langdetect immutabledict   # once (pinned: the JSON gen_kwargs form and log sentinels are version-coupled)
+PARITY_API_KEY="" ./run_parity_bench.sh mybox "http://localhost:8888/v1/chat/completions"
 # results land in ./parity-results/<run>/, resumable via .done markers
+# (the key travels via env, not argv — argv is visible in `ps`)
+# The script first fingerprints whether your endpoint renders reasoning_effort
+# (1-token probe) and refuses to start if it doesn't — stock vLLM silently
+# ignores the field, and a no-effort campaign is not card-comparable.
 ```
 
 Three seeds per benchmark; compare your medians to the card. Interpretation:
@@ -49,7 +61,7 @@ Three seeds per benchmark; compare your medians to the card. Interpretation:
   in the run logs first (`grep -c "null content" *.log`).
 - **High nulls** → truncation (raise `max_gen_toks`) or the stop-string bug (see below).
 
-## Traps this harness already avoids (learned the hard way)
+## Traps (learned the hard way) — 1, 2 and 4 are enforced by the harness; 3 and 5 are documented so you can check for them
 
 1. **Stop-strings inside reasoning** — think-in-prompt models restate phrases like
    "Question:" while reasoning; serving stacks that match client stop-strings in the

--- a/parity/README.md
+++ b/parity/README.md
@@ -29,6 +29,11 @@ hosted deployment, protocol v3 (`reasoning_effort: max`, temp 0.6 / top_p 0.95, 
 You do NOT need to re-buy this card. It is a property of the checkpoint. Your local
 runs compare against it directly.
 
+The card also carries reference-only rows the run script does not reproduce (GSM8K,
+AA-LCR, HLE, SciCode, LiveCodeBench, Terminal-Bench-hard, τ²-telecom) — each with its
+harness, protocol, and caveats spelled out in the card's `notes`. Treat those as
+context, not as parity targets.
+
 ## Run it
 
 ```bash

--- a/parity/campaign_watcher.sh
+++ b/parity/campaign_watcher.sh
@@ -1,36 +1,37 @@
 #!/usr/bin/env bash
-# Centinela de la campaña AA-Index: sale ≠0 ante fallo (proceso muerto, logs
-# estancados 15 min, ráfaga de errores); sale 0 al completarse (18 .done).
+# Campaign sentinel: exits non-zero on failure (dead workers, logs stalled
+# 15 min, error burst); exits 0 when the campaign completes (all .done markers).
+# Watches ARTIFACTS (.done files, log growth), not process lifetimes.
 set -u
-OUT=/home/ludwid/lm-eval/aa-index
-EXPECTED_DONE=24
+OUT="${PARITY_OUT:-./parity-results}"
+EXPECTED_DONE="${EXPECTED_DONE:-9}"
 STALL_LIMIT=3
 prev_size=-1; stalls=0; t0=$(date +%s)
 while :; do
   done_count=$(ls "$OUT"/*.done 2>/dev/null | wc -l)
   if [ "$done_count" -ge "$EXPECTED_DONE" ]; then
-    echo "CAMPAÑA COMPLETA: $done_count/$EXPECTED_DONE runs"; exit 0
+    echo "CAMPAIGN COMPLETE: $done_count/$EXPECTED_DONE runs"; exit 0
   fi
   if [ $(( $(date +%s) - t0 )) -gt 32400 ]; then
-    echo "TIMEOUT 9h con $done_count/$EXPECTED_DONE"; exit 2
+    echo "TIMEOUT 9h with $done_count/$EXPECTED_DONE"; exit 2
   fi
   procs=$(pgrep -fc "[l]m_eval --model" || true)
   if [ "${procs:-0}" -lt 1 ]; then
-    echo "FALLO: cero workers lm_eval vivos con $done_count/$EXPECTED_DONE done"
+    echo "FAILURE: zero live lm_eval workers with $done_count/$EXPECTED_DONE done"
     ps -eo pid,etime,args | grep "[l]m_eval --model" | head -4; exit 1
   fi
   for f in "$OUT"/*.log; do
     [ -f "$f" ] || continue
     errs=$(grep -cE "HTTP Error 4|HTTP Error 5|Traceback|ConnectionError" "$f")
     if [ "$errs" -gt 40 ]; then
-      echo "FALLO: $(basename $f) acumula $errs errores"; tail -5 "$f"; exit 1
+      echo "FAILURE: $(basename $f) accumulated $errs errors"; tail -5 "$f"; exit 1
     fi
   done
   size=$(cat "$OUT"/*.log 2>/dev/null | wc -c)
   if [ "$size" = "$prev_size" ]; then
     stalls=$((stalls+1))
     if [ "$stalls" -ge "$STALL_LIMIT" ]; then
-      echo "FALLO: logs sin crecer 15 min ($done_count/$EXPECTED_DONE done)"
+      echo "FAILURE: logs stopped growing for 15 min ($done_count/$EXPECTED_DONE done)"
       for f in "$OUT"/*.log; do printf "%s: %s\n" "$(basename $f)" "$(grep -oE 'Requesting API: +[0-9]+%' $f | tail -1)"; done
       exit 1
     fi

--- a/parity/campaign_watcher.sh
+++ b/parity/campaign_watcher.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Centinela de la campaña AA-Index: sale ≠0 ante fallo (proceso muerto, logs
+# estancados 15 min, ráfaga de errores); sale 0 al completarse (18 .done).
+set -u
+OUT=/home/ludwid/lm-eval/aa-index
+EXPECTED_DONE=24
+STALL_LIMIT=3
+prev_size=-1; stalls=0; t0=$(date +%s)
+while :; do
+  done_count=$(ls "$OUT"/*.done 2>/dev/null | wc -l)
+  if [ "$done_count" -ge "$EXPECTED_DONE" ]; then
+    echo "CAMPAÑA COMPLETA: $done_count/$EXPECTED_DONE runs"; exit 0
+  fi
+  if [ $(( $(date +%s) - t0 )) -gt 32400 ]; then
+    echo "TIMEOUT 9h con $done_count/$EXPECTED_DONE"; exit 2
+  fi
+  procs=$(pgrep -fc "[l]m_eval --model" || true)
+  if [ "${procs:-0}" -lt 1 ]; then
+    echo "FALLO: cero workers lm_eval vivos con $done_count/$EXPECTED_DONE done"
+    ps -eo pid,etime,args | grep "[l]m_eval --model" | head -4; exit 1
+  fi
+  for f in "$OUT"/*.log; do
+    [ -f "$f" ] || continue
+    errs=$(grep -cE "HTTP Error 4|HTTP Error 5|Traceback|ConnectionError" "$f")
+    if [ "$errs" -gt 40 ]; then
+      echo "FALLO: $(basename $f) acumula $errs errores"; tail -5 "$f"; exit 1
+    fi
+  done
+  size=$(cat "$OUT"/*.log 2>/dev/null | wc -c)
+  if [ "$size" = "$prev_size" ]; then
+    stalls=$((stalls+1))
+    if [ "$stalls" -ge "$STALL_LIMIT" ]; then
+      echo "FALLO: logs sin crecer 15 min ($done_count/$EXPECTED_DONE done)"
+      for f in "$OUT"/*.log; do printf "%s: %s\n" "$(basename $f)" "$(grep -oE 'Requesting API: +[0-9]+%' $f | tail -1)"; done
+      exit 1
+    fi
+  else
+    stalls=0
+  fi
+  prev_size=$size
+  sleep 300
+done

--- a/parity/campaign_watcher.sh
+++ b/parity/campaign_watcher.sh
@@ -12,8 +12,11 @@ while :; do
   if [ "$done_count" -ge "$EXPECTED_DONE" ]; then
     echo "CAMPAIGN COMPLETE: $done_count/$EXPECTED_DONE runs"; exit 0
   fi
-  if [ $(( $(date +%s) - t0 )) -gt 32400 ]; then
-    echo "TIMEOUT 9h with $done_count/$EXPECTED_DONE"; exit 2
+  # mmlu_pro is 1120 items/run at --limit 80 (14 subtasks), so a healthy
+  # campaign runs far past 9h at c6 — default sized to the real workload,
+  # env-tunable for faster endpoints (review #34, item 3).
+  if [ $(( $(date +%s) - t0 )) -gt "${WATCH_TIMEOUT_SEC:-129600}" ]; then
+    echo "TIMEOUT $(( ${WATCH_TIMEOUT_SEC:-129600} / 3600 ))h with $done_count/$EXPECTED_DONE"; exit 2
   fi
   procs=$(pgrep -fc "[l]m_eval --model" || true)
   if [ "${procs:-0}" -lt 1 ]; then
@@ -22,7 +25,9 @@ while :; do
   fi
   for f in "$OUT"/*.log; do
     [ -f "$f" ] || continue
-    errs=$(grep -cE "HTTP Error 4|HTTP Error 5|Traceback|ConnectionError" "$f")
+    # "API request failed" is 0.4.12's async-path failure log line — without it
+    # an endpoint dying mid-run waited for the 15-min stall check (review #34, item 3).
+    errs=$(grep -cE "HTTP Error 4|HTTP Error 5|Traceback|ConnectionError|API request failed" "$f")
     if [ "$errs" -gt 40 ]; then
       echo "FAILURE: $(basename $f) accumulated $errs errors"; tail -5 "$f"; exit 1
     fi

--- a/parity/reference-card_hosted_v3.json
+++ b/parity/reference-card_hosted_v3.json
@@ -28,7 +28,12 @@
    "ifeval": 80,
    "gpqa_diamond_cot_zeroshot": 60,
    "gsm8k": 50,
-   "aa_lcr": 100
+   "aa_lcr": 100,
+   "hle_text": 120,
+   "scicode": 65,
+   "lcb_codegen": 175,
+   "tb_hard": 44,
+   "tau2_telecom": 114
   }
  },
  "metric_keys": {
@@ -37,7 +42,13 @@
   "ifeval": "prompt_level_strict_acc,none",
   "gpqa_diamond_cot_zeroshot": "exact_match,flexible-extract",
   "gsm8k": "exact_match,flexible-extract",
-  "aa_lcr": "judge_equivalence(ds4-flash, shared)"
+  "aa_lcr": "judge_equivalence(ds4-flash, shared)",
+  "hle_text": "judge_equivalence(ds4-flash, shared)",
+  "scicode_sub": "subproblem_correctness (inspect-ai scorer)",
+  "scicode_main": "problem_correctness (inspect-ai scorer)",
+  "lcb_codegen": "pass@1 (official harness eval)",
+  "tb_hard": "resolved_rate (Terminus-2, pass@1)",
+  "tau2_telecom": "pass^1 (ENV_ASSERTION/ACTION checks)"
  },
  "results": {
   "aime25": {
@@ -91,9 +102,56 @@
     0.65
    ],
    "n_runs": 1
+  },
+  "hle_text": {
+   "median": 0.15,
+   "runs": [
+    0.15
+   ],
+   "n_runs": 1
+  },
+  "scicode_sub": {
+   "median": 0.3127,
+   "runs": [
+    0.3127
+   ],
+   "n_runs": 1
+  },
+  "scicode_main": {
+   "median": 0.0462,
+   "runs": [
+    0.0462
+   ],
+   "n_runs": 1
+  },
+  "lcb_codegen": {
+   "median": 0.5657,
+   "runs": [
+    0.5657
+   ],
+   "n_runs": 1
+  },
+  "tb_hard": {
+   "median": 0.4524,
+   "runs": [
+    0.4524
+   ],
+   "n_runs": 1
+  },
+  "tau2_telecom": {
+   "median": 1.0,
+   "runs": [
+    1.0
+   ],
+   "n_runs": 1
   }
  },
  "notes": {
-  "aa_lcr": "juez compartido ds4-flash (oficial no especificado); n_runs=1 por coste de input (~10M tok); contexts ~100K tok"
+  "aa_lcr": "juez compartido ds4-flash (oficial no especificado); n_runs=1 por coste de input (~10M tok); contexts ~100K tok",
+  "hle_text": "subset texto (sin imagen), muestreo fijo seed 1234 de 2500; plantilla oficial Explanation/Answer/Confidence; juez compartido (oficial usa o3-mini)",
+  "scicode": "harness=inspect-ai 0.3.69 (integración oficial SciCode; no existe task lm-eval); split test, 65 problemas / 291 subproblemas, SIN background anotado (setting duro estándar); max_tokens=30000 (14/288 generaciones aún truncadas — effort max es hambriento); effort=max vía parche env-gated del provider openai de inspect-ai; banda de referencia: DeepSeek-R1 leaderboard = 4.6 main / 28.5 sub",
+  "lcb_codegen": "harness oficial LiveCodeBench @28fef95, code_generation_lite v6 (175 problemas, ventana 2025-01→2025-04 — la más reciente publicada; anterior al checkpoint 0731, contaminación no descartable); breakdown easy 43/43, medium 38/52, hard 18/80; 82/175 tocaron el cap de 30K (68 sin código extraíble → 0) — el split hard está limitado por presupuesto a effort=max, no puramente por capacidad",
+  "tb_hard": "subset AA-hard 44 tareas @74221fb (42 puntuadas; sin correr: ['polyglot-rust-c', 'write-compressor']); 1 repetición; timeout uniforme 3600s (AA usa defaults por tarea + global 24h + presupuesto 1M input/rep — no aplicados por el harness 0.2.18); scaffold Terminus-2 default; contadores de tokens en 0 (bug del harness), coste estimado $4-8; comparable en espíritu, no citable como metodología AA",
+  "tau2_telecom": "114/114, tau2-bench v1.0.1 telecom base split, 1 trial; agente DS4 (temp 0.6, 30K, sin stops), user-sim gpt-5.6-luna temp 0.0 (Zen); verificado: 209/209 env assertions, 516/516 action checks, 1894 llamadas agente + 2553 sim con metadata real, terminación user_stop en todas; coste $4.35. PERFECTO > SOTA publicado — leer con cautela: n=1, sim complaciente a temp 0, max_steps 200 generoso, split base upstream; comparable en espíritu, no citable como metodología AA"
  }
 }

--- a/parity/reference-card_hosted_v3.json
+++ b/parity/reference-card_hosted_v3.json
@@ -34,6 +34,24 @@
    "lcb_codegen": 175,
    "tb_hard": 44,
    "tau2_telecom": 114
+  },
+  "limits_note": "--limit is per-subtask in lm-eval: mmlu_pro (14 subtasks) at --limit 80 is n=1120 total. All other tasks are single-task (limit = n).",
+  "effective_n": {
+   "mmlu_pro": 1120,
+   "aime25": 30,
+   "ifeval": 80,
+   "gpqa_diamond_cot_zeroshot": 60,
+   "gsm8k": 50
+  },
+  "seed_note": "The three hosted runs were launched with --seed only, which in lm-eval 0.4.12 seeds python/numpy/torch/fewshot but NOT the request payload (that is the --model_args seed, which defaulted to 1234 for all runs). The run-to-run spread in this card therefore reflects server-side nondeterminism, not sampler seeds. run_parity_bench.sh now passes seed into --model_args, so local runs ARE seed-independent samples.",
+  "effort_render_fingerprint": {
+   "method": "1-token request, prompt_tokens readback: bare vs reasoning_effort=max",
+   "reference_deltas": {
+    "none": 0,
+    "high": 79,
+    "max": 92
+   },
+   "hosted_card_value": "not captured at card freeze (2026-08-05) — a deviation from this card can be card-side if the hosted backend rendered a different preamble; any card revision must capture it. run_parity_bench.sh now records the local value in parity-results/effort_fingerprint.txt and aborts on delta 0 (stock vLLM ignores reasoning_effort entirely)."
   }
  },
  "metric_keys": {
@@ -153,5 +171,11 @@
   "lcb_codegen": "official LiveCodeBench harness @28fef95, code_generation_lite v6 (175 problems, window 2025-01→2025-04 — most recent published; predates the 0731 checkpoint, contamination not ruled out); breakdown easy 43/43, medium 38/52, hard 18/80; 82/175 hit the 30K cap (68 with no extractable code → 0) — the hard split is budget-limited at effort=max, not purely capability-limited",
   "tb_hard": "AA-hard subset, 44 tasks @74221fb (42 scored; not run: ['polyglot-rust-c', 'write-compressor']); 1 repetition; uniform 3600s timeout (AA uses per-task defaults + global 24h + 1M-input/rep budget — not enforced by harness 0.2.18); default Terminus-2 scaffold; token counters at 0 (harness bug), estimated cost $4-8; comparable in spirit, not citable as AA methodology",
   "tau2_telecom": "114/114, tau2-bench v1.0.1 telecom base split, 1 trial; DS4 agent (temp 0.6, 30K, no stops), user-sim gpt-5.6-luna temp 0.0 (hosted aggregator); verified: 209/209 env assertions, 516/516 action checks, 1894 agent + 2553 sim calls with real metadata, user_stop termination on all; cost $4.35. PERFECT > published SOTA — read with caution: n=1, compliant sim at temp 0, generous max_steps 200, upstream base split; comparable in spirit, not citable as AA methodology"
- }
+ },
+ "parity_targets": [
+  "mmlu_pro",
+  "aime25",
+  "ifeval"
+ ],
+ "non_targets_note": "Rows outside parity_targets are reference context only (different harnesses/costs; see notes) — they are not reproduced by run_parity_bench.sh."
 }

--- a/parity/reference-card_hosted_v3.json
+++ b/parity/reference-card_hosted_v3.json
@@ -18,20 +18,23 @@
    "mmlu_pro": 24000,
    "aime25": 30000,
    "ifeval": 16000,
-   "gpqa_diamond": 20000
+   "gpqa_diamond": 20000,
+   "gsm8k": 14000
   },
   "limits": {
    "mmlu_pro": 80,
    "aime25": 30,
    "ifeval": 80,
-   "gpqa_diamond_cot_zeroshot": 60
+   "gpqa_diamond_cot_zeroshot": 60,
+   "gsm8k": 50
   }
  },
  "metric_keys": {
   "mmlu_pro": "exact_match,custom-extract",
   "aime25": "exact_match,none",
   "ifeval": "prompt_level_strict_acc,none",
-  "gpqa_diamond_cot_zeroshot": "exact_match,flexible-extract"
+  "gpqa_diamond_cot_zeroshot": "exact_match,flexible-extract",
+  "gsm8k": "exact_match,flexible-extract"
  },
  "results": {
   "aime25": {
@@ -67,6 +70,15 @@
     0.8259,
     0.8366,
     0.8411
+   ],
+   "n_runs": 3
+  },
+  "gsm8k": {
+   "median": 1.0,
+   "runs": [
+    0.98,
+    1.0,
+    1.0
    ],
    "n_runs": 3
   }

--- a/parity/reference-card_hosted_v3.json
+++ b/parity/reference-card_hosted_v3.json
@@ -1,0 +1,74 @@
+{
+ "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+ "endpoint": "opencode-zen-paid",
+ "provider_fingerprint": "extra_sampling_logprobs/last_activation schema (≈fireworks, sin confirmación oficial)",
+ "protocol": {
+  "version": "v3",
+  "reasoning_effort": "max",
+  "temperature": 0.6,
+  "top_p": 0.95,
+  "seeds": [
+   1234,
+   2345,
+   3456
+  ],
+  "harness": "lm-eval 0.4.12",
+  "date_frozen": "2026-08-05",
+  "budgets": {
+   "mmlu_pro": 24000,
+   "aime25": 30000,
+   "ifeval": 16000,
+   "gpqa_diamond": 20000
+  },
+  "limits": {
+   "mmlu_pro": 80,
+   "aime25": 30,
+   "ifeval": 80,
+   "gpqa_diamond_cot_zeroshot": 60
+  }
+ },
+ "metric_keys": {
+  "mmlu_pro": "exact_match,custom-extract",
+  "aime25": "exact_match,none",
+  "ifeval": "prompt_level_strict_acc,none",
+  "gpqa_diamond_cot_zeroshot": "exact_match,flexible-extract"
+ },
+ "results": {
+  "aime25": {
+   "median": 0.7,
+   "runs": [
+    0.7,
+    0.7,
+    0.7333
+   ],
+   "n_runs": 3
+  },
+  "ifeval": {
+   "median": 0.9375,
+   "runs": [
+    0.9,
+    0.9375,
+    0.9375
+   ],
+   "n_runs": 3
+  },
+  "gpqa_diamond_cot_zeroshot": {
+   "median": 0.7333,
+   "runs": [
+    0.6667,
+    0.7333,
+    0.7667
+   ],
+   "n_runs": 3
+  },
+  "mmlu_pro": {
+   "median": 0.8366,
+   "runs": [
+    0.8259,
+    0.8366,
+    0.8411
+   ],
+   "n_runs": 3
+  }
+ }
+}

--- a/parity/reference-card_hosted_v3.json
+++ b/parity/reference-card_hosted_v3.json
@@ -1,7 +1,7 @@
 {
  "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
- "endpoint": "opencode-zen-paid",
- "provider_fingerprint": "extra_sampling_logprobs/last_activation schema (≈fireworks, sin confirmación oficial)",
+ "endpoint": "hosted-aggregator (paid tier, provider-pinned per response)",
+ "provider_fingerprint": "extra_sampling_logprobs/last_activation schema (≈fireworks, no official confirmation)",
  "protocol": {
   "version": "v3",
   "reasoning_effort": "max",
@@ -149,9 +149,9 @@
  "notes": {
   "aa_lcr": "juez compartido ds4-flash (oficial no especificado); n_runs=1 por coste de input (~10M tok); contexts ~100K tok",
   "hle_text": "subset texto (sin imagen), muestreo fijo seed 1234 de 2500; plantilla oficial Explanation/Answer/Confidence; juez compartido (oficial usa o3-mini)",
-  "scicode": "harness=inspect-ai 0.3.69 (integración oficial SciCode; no existe task lm-eval); split test, 65 problemas / 291 subproblemas, SIN background anotado (setting duro estándar); max_tokens=30000 (14/288 generaciones aún truncadas — effort max es hambriento); effort=max vía parche env-gated del provider openai de inspect-ai; banda de referencia: DeepSeek-R1 leaderboard = 4.6 main / 28.5 sub",
-  "lcb_codegen": "harness oficial LiveCodeBench @28fef95, code_generation_lite v6 (175 problemas, ventana 2025-01→2025-04 — la más reciente publicada; anterior al checkpoint 0731, contaminación no descartable); breakdown easy 43/43, medium 38/52, hard 18/80; 82/175 tocaron el cap de 30K (68 sin código extraíble → 0) — el split hard está limitado por presupuesto a effort=max, no puramente por capacidad",
-  "tb_hard": "subset AA-hard 44 tareas @74221fb (42 puntuadas; sin correr: ['polyglot-rust-c', 'write-compressor']); 1 repetición; timeout uniforme 3600s (AA usa defaults por tarea + global 24h + presupuesto 1M input/rep — no aplicados por el harness 0.2.18); scaffold Terminus-2 default; contadores de tokens en 0 (bug del harness), coste estimado $4-8; comparable en espíritu, no citable como metodología AA",
-  "tau2_telecom": "114/114, tau2-bench v1.0.1 telecom base split, 1 trial; agente DS4 (temp 0.6, 30K, sin stops), user-sim gpt-5.6-luna temp 0.0 (Zen); verificado: 209/209 env assertions, 516/516 action checks, 1894 llamadas agente + 2553 sim con metadata real, terminación user_stop en todas; coste $4.35. PERFECTO > SOTA publicado — leer con cautela: n=1, sim complaciente a temp 0, max_steps 200 generoso, split base upstream; comparable en espíritu, no citable como metodología AA"
+  "scicode": "harness=inspect-ai 0.3.69 (official SciCode integration; no lm-eval task exists); test split, 65 problems / 291 subproblems, WITHOUT annotated background (standard hard setting); max_tokens=30000 (14/288 generations still truncated — effort max is hungry); effort=max via env-gated patch of inspect-ai's openai provider; reference band: DeepSeek-R1 leaderboard = 4.6 main / 28.5 sub",
+  "lcb_codegen": "official LiveCodeBench harness @28fef95, code_generation_lite v6 (175 problems, window 2025-01→2025-04 — most recent published; predates the 0731 checkpoint, contamination not ruled out); breakdown easy 43/43, medium 38/52, hard 18/80; 82/175 hit the 30K cap (68 with no extractable code → 0) — the hard split is budget-limited at effort=max, not purely capability-limited",
+  "tb_hard": "AA-hard subset, 44 tasks @74221fb (42 scored; not run: ['polyglot-rust-c', 'write-compressor']); 1 repetition; uniform 3600s timeout (AA uses per-task defaults + global 24h + 1M-input/rep budget — not enforced by harness 0.2.18); default Terminus-2 scaffold; token counters at 0 (harness bug), estimated cost $4-8; comparable in spirit, not citable as AA methodology",
+  "tau2_telecom": "114/114, tau2-bench v1.0.1 telecom base split, 1 trial; DS4 agent (temp 0.6, 30K, no stops), user-sim gpt-5.6-luna temp 0.0 (hosted aggregator); verified: 209/209 env assertions, 516/516 action checks, 1894 agent + 2553 sim calls with real metadata, user_stop termination on all; cost $4.35. PERFECT > published SOTA — read with caution: n=1, compliant sim at temp 0, generous max_steps 200, upstream base split; comparable in spirit, not citable as AA methodology"
  }
 }

--- a/parity/reference-card_hosted_v3.json
+++ b/parity/reference-card_hosted_v3.json
@@ -19,14 +19,16 @@
    "aime25": 30000,
    "ifeval": 16000,
    "gpqa_diamond": 20000,
-   "gsm8k": 14000
+   "gsm8k": 14000,
+   "aa_lcr": 6000
   },
   "limits": {
    "mmlu_pro": 80,
    "aime25": 30,
    "ifeval": 80,
    "gpqa_diamond_cot_zeroshot": 60,
-   "gsm8k": 50
+   "gsm8k": 50,
+   "aa_lcr": 100
   }
  },
  "metric_keys": {
@@ -34,7 +36,8 @@
   "aime25": "exact_match,none",
   "ifeval": "prompt_level_strict_acc,none",
   "gpqa_diamond_cot_zeroshot": "exact_match,flexible-extract",
-  "gsm8k": "exact_match,flexible-extract"
+  "gsm8k": "exact_match,flexible-extract",
+  "aa_lcr": "judge_equivalence(ds4-flash, shared)"
  },
  "results": {
   "aime25": {
@@ -81,6 +84,16 @@
     1.0
    ],
    "n_runs": 3
+  },
+  "aa_lcr": {
+   "median": 0.65,
+   "runs": [
+    0.65
+   ],
+   "n_runs": 1
   }
+ },
+ "notes": {
+  "aa_lcr": "juez compartido ds4-flash (oficial no especificado); n_runs=1 por coste de input (~10M tok); contexts ~100K tok"
  }
 }

--- a/parity/run_parity_bench.sh
+++ b/parity/run_parity_bench.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Campaña AA-Index Tier A: {mmlu_pro, aime25, ifeval} × 3 seeds × 1 endpoint.
+# Uso: run_campaign.sh <endpoint-name> <base_url> [api_key]
+set -u
+EP="$1"; URL="$2"; KEY="${3:-}"
+OUT="${PARITY_OUT:-./parity-results}"; mkdir -p "$OUT"
+LM="${LM_EVAL:-lm_eval}"
+for SEED in 1234 2345 3456; do
+  for SPEC in "mmlu_pro:80:24000" "aime25:30:30000" "ifeval:80:16000"; do
+    TASK="${SPEC%%:*}"; REST="${SPEC#*:}"; LIMIT="${REST%%:*}"; TOKS="${REST#*:}"
+    TAG="${EP}_${TASK}_s${SEED}"
+    [ -f "$OUT/$TAG.done" ] && continue
+    echo "=== $TAG @ $(date +%H:%M)"
+    OPENAI_API_KEY="$KEY" $LM --model local-chat-completions \
+      --model_args "model=deepseek-v4-flash,base_url=$URL,num_concurrent=6,max_retries=3,timeout=1800" \
+      --tasks "$TASK" --limit "$LIMIT" --apply_chat_template \
+      --gen_kwargs "{\"temperature\":0.6,\"top_p\":0.95,\"reasoning_effort\":\"max\",\"max_gen_toks\":$TOKS,\"until\":[]}" \
+      --output_path "$OUT/$TAG" --seed "$SEED" > "$OUT/$TAG.log" 2>&1 \
+      && touch "$OUT/$TAG.done"
+    echo "    exit=$? nulls=$(grep -c 'null content' "$OUT/$TAG.log")"
+  done
+done
+echo "CAMPAIGN $EP COMPLETE $(date +%H:%M)"

--- a/parity/run_parity_bench.sh
+++ b/parity/run_parity_bench.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Campaña AA-Index Tier A: {mmlu_pro, aime25, ifeval} × 3 seeds × 1 endpoint.
-# Uso: run_campaign.sh <endpoint-name> <base_url> [api_key]
+# Parity bench Tier A: {mmlu_pro, aime25, ifeval} x 3 seeds x 1 endpoint.
+# Usage: run_parity_bench.sh <endpoint-name> <base_url> [api_key]
 set -u
 EP="$1"; URL="$2"; KEY="${3:-}"
 OUT="${PARITY_OUT:-./parity-results}"; mkdir -p "$OUT"

--- a/parity/run_parity_bench.sh
+++ b/parity/run_parity_bench.sh
@@ -1,19 +1,57 @@
 #!/usr/bin/env bash
 # Parity bench Tier A: {mmlu_pro, aime25, ifeval} x 3 seeds x 1 endpoint.
-# Usage: run_parity_bench.sh <endpoint-name> <base_url> [api_key]
+# Usage:  PARITY_API_KEY=sk-... run_parity_bench.sh <endpoint-name> <base_url>
+# (A third argv is still accepted for the key but the env var is preferred —
+#  argv is visible to every user on the box via `ps`.)
+# NOTE: mmlu_pro's --limit is per-subtask (14 subtasks) → n=1120, and the
+# campaign is a multi-hour/overnight affair at typical c6 throughput.
 set -u
-EP="$1"; URL="$2"; KEY="${3:-}"
+EP="$1"; URL="$2"; KEY="${PARITY_API_KEY:-${3:-}}"
 OUT="${PARITY_OUT:-./parity-results}"; mkdir -p "$OUT"
 LM="${LM_EVAL:-lm_eval}"
+
+# ── Effort-render preflight (review #34, item 4) ────────────────────────────
+# Fingerprints whether the endpoint actually renders `reasoning_effort` BEFORE
+# the campaign spends anything: a 1-token request bare vs effort=max, read back
+# via prompt_tokens. A backend that renders the effort preamble shows a delta
+# (pair-measured: none=+0, high=+79, max=+92); stock vLLM silently ignores the
+# field entirely (delta 0) — running the campaign there measures a DIFFERENT
+# protocol than the card. Abort on delta 0 unless PARITY_ALLOW_NO_EFFORT=1.
+# The fingerprint is stored next to the results so the card comparison can
+# carry it. (The fingerprinting technique is issue #33's, turned into a guard.)
+_pt() {
+  curl -s --max-time 60 "$URL" -H "Content-Type: application/json" \
+    ${KEY:+-H "Authorization: Bearer $KEY"} \
+    -d "{\"model\":\"deepseek-v4-flash\",\"max_tokens\":1,$1\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}" \
+  | python3 -c 'import json,sys
+try: print(json.load(sys.stdin)["usage"]["prompt_tokens"])
+except Exception: print(-1)'
+}
+PT_BARE=$(_pt "")
+PT_MAX=$(_pt "\"reasoning_effort\":\"max\",")
+if [ "$PT_BARE" -lt 0 ] || [ "$PT_MAX" -lt 0 ]; then
+  echo "PREFLIGHT FAILED: endpoint did not answer the 1-token fingerprint probes ($URL)"; exit 1
+fi
+DELTA=$((PT_MAX - PT_BARE))
+echo "effort fingerprint: bare=$PT_BARE max=$PT_MAX delta=+$DELTA" | tee "$OUT/effort_fingerprint.txt"
+if [ "$DELTA" -eq 0 ] && [ "${PARITY_ALLOW_NO_EFFORT:-0}" != "1" ]; then
+  echo "PREFLIGHT ABORT: endpoint does not render reasoning_effort (delta 0) —"
+  echo "  your runs would measure a different protocol than the reference card."
+  echo "  Set PARITY_ALLOW_NO_EFFORT=1 to run anyway (results are NOT card-comparable)."
+  exit 1
+fi
+
 for SEED in 1234 2345 3456; do
   for SPEC in "mmlu_pro:80:24000" "aime25:30:30000" "ifeval:80:16000"; do
     TASK="${SPEC%%:*}"; REST="${SPEC#*:}"; LIMIT="${REST%%:*}"; TOKS="${REST#*:}"
     TAG="${EP}_${TASK}_s${SEED}"
     [ -f "$OUT/$TAG.done" ] && continue
     echo "=== $TAG @ $(date +%H:%M)"
+    # seed=$SEED in --model_args is the one that reaches the request payload;
+    # --seed alone only seeds python/numpy/torch/fewshot (review #34, item 1).
     OPENAI_API_KEY="$KEY" $LM --model local-chat-completions \
-      --model_args "model=deepseek-v4-flash,base_url=$URL,num_concurrent=6,max_retries=3,timeout=1800" \
-      --tasks "$TASK" --limit "$LIMIT" --apply_chat_template \
+      --model_args "model=deepseek-v4-flash,base_url=$URL,num_concurrent=6,max_retries=3,timeout=1800,seed=$SEED" \
+      --tasks "$TASK" --limit "$LIMIT" --apply_chat_template --log_samples \
       --gen_kwargs "{\"temperature\":0.6,\"top_p\":0.95,\"reasoning_effort\":\"max\",\"max_gen_toks\":$TOKS,\"until\":[]}" \
       --output_path "$OUT/$TAG" --seed "$SEED" > "$OUT/$TAG.log" 2>&1 \
       && touch "$OUT/$TAG.done"


### PR DESCRIPTION
The reproducible half of #18's fidelity investigation, promised there on 08-12: a `parity/` folder that lets any deployment of this recipe answer, with hard numbers in ~1–2h of wall clock, **"is my serving faithful to the checkpoint, or is my stack silently costing me intelligence?"**

**What's in it**

- `run_parity_bench.sh` — Tier A campaign: {MMLU-Pro 80, AIME'25 30, IFEval 80} × seeds 1234/2345/3456 via lm-eval `local-chat-completions`, `until: []` (so it measures correctly on stacks that still evaluate stops in reasoning), resumable via `.done` markers.
- `reference-card_hosted_v3.json` — the frozen hosted reference for `DeepSeek-V4-Flash-0731` (protocol v3: effort=max, t0.6/p0.95, fixed slices, lm-eval 0.4.12): IFEval **0.938**, MMLU-Pro **0.837**, GPQA-D **0.733**, AIME'25 **0.700** (all runs listed, medians with ranges). It's a property of the checkpoint — nobody needs to re-buy it. Reference-only rows (GSM8K, AA-LCR, HLE, SciCode, LCB, TB-hard, τ²-telecom) carry their own harness + caveats in `notes` and are context, not parity targets.
- `campaign_watcher.sh` — artifact-watching sentinel (`.done` count, log growth, error bursts), exits non-zero on failure.
- `parity/README.md` — interpretation guide + the five traps this harness already avoids (stop-strings-in-reasoning, budget truncation ≠ model failure, runaway-loop tail, single-prompt A/B noise, grouped-task score keys).

**Why it belongs in this repo**: while debugging #18 we measured a 25-point GSM8K gap between this stack and a hosted deployment of the identical checkpoint — all serving-layer. After the fixes, the 2× GB10 pair matched the hosted reference exactly (IFEval 0.9375 = 0.9375 first paired run). Deviation from the card = actionable serving defect; that's the entire premise, and every future patch to this recipe can be gated on it.

Dogfooded: this is the exact harness + card used for the paired runs published in #18 (08-12 → 08-15); the folder is the cleaned, env-driven version (no absolute paths, `PARITY_OUT` for results).
