### PR TITLE
docs: dual-HCA QSFP config — both virtual NICs or NCCL runs at half the port (98→161 Gb/s)

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -19,9 +19,18 @@ HEADLESS=
 # HEADLESS=1
 
 # RoCE / InfiniBand
-NCCL_IB_HCA=rocepXsYfZ
-NCCL_SOCKET_IFNAME=enpXsYfZnpN
-NCCL_IB_GID_INDEX=0
+# The GB10 QSFP port enumerates as TWO virtual NICs (2x PCIe x4 controllers,
+# ~100G each). If only one is configured, node-to-node NCCL is capped at about
+# half the port: we measured 98 Gb/s single-HCA vs 161 Gb/s with both merged
+# (+64%) on nccl-tests busbw. Give BOTH interfaces an IP (separate subnets) and
+# MTU 9000, list both HCAs here, and set NCCL_IB_MERGE_NICS=1. Interface names
+# vary per box - map them with `ibdev2netdev`.
+NCCL_IB_HCA=rocepXsYfZ,rocePWpXsYfZ
+NCCL_SOCKET_IFNAME=enpXsYfZnpN,enPWpXsYfZnpN
+NCCL_IB_MERGE_NICS=1
+# GID 3 = RoCEv2. Verify per port before serving:
+#   cat /sys/class/infiniband/<hca>/ports/1/gid_attrs/types/3   -> "RoCE v2"
+NCCL_IB_GID_INDEX=3
 NCCL_CROSS_NIC=1
 
 # Caches / model

--- a/DEFAULT-CONFIG.md
+++ b/DEFAULT-CONFIG.md
@@ -162,6 +162,21 @@ PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 NCCL_NET=IB  NCCL_IB_DISABLE=0  NCCL_IB_HCA=rocep1s0f0  NCCL_SOCKET_IFNAME=enp1s0f0np0
 NCCL_IB_GID_INDEX=3  NCCL_CROSS_NIC=1  NCCL_CUMEM_ENABLE=0  NCCL_IGNORE_CPU_AFFINITY=1
 NCCL_DEBUG=WARN  NCCL_NVLS_ENABLE=0
+```
+
+> **Dual-HCA note (direct QSFP pairs):** the GB10 QSFP port is TWO virtual NICs
+> (2x PCIe x4). With only one configured, NCCL runs at ~half the port: measured
+> 98 Gb/s single vs **161 Gb/s** with both HCAs listed and `NCCL_IB_MERGE_NICS=1`
+> (+64% busbw, nccl-tests). Both interfaces need an IP (separate subnets) and MTU
+> 9000; map names with `ibdev2netdev`; confirm GID 3 is RoCE v2 via
+> `/sys/class/infiniband/<hca>/ports/1/gid_attrs/types/3`. Two related traps:
+> pre-2026-04 BIOS wires the second controller at Gen5 x2 (half bandwidth -
+> update via `fwupdmgr` first), and GB10 has no GPUDirect RDMA (GDR 0), which is
+> the remaining decode ceiling. On a switched fabric (like the CRS812 setup
+> above) the second NIC may be deliberately unused - this note is for
+> back-to-back QSFP pairs chasing interconnect-bound decode.
+
+```
 HF_HUB_OFFLINE=1  TRANSFORMERS_OFFLINE=1  HF_HUB_DISABLE_XET=1  HF_HOME=/cache/huggingface  VLLM_CACHE_ROOT=/cache/huggingface/vllm-cache
 ```
 


### PR DESCRIPTION
Doc-only PR: the dual-HCA QSFP finding from our GX10 pair, since the current `.env.dspark.example` shows a single-HCA config (and `NCCL_IB_GID_INDEX=0`).

**The trap:** the GB10 QSFP port enumerates as **two** virtual NICs (2× PCIe x4 controllers). Out of the box only one is configured, and node-to-node NCCL caps at roughly half the port. Measured on our back-to-back pair (nccl-tests busbw): **98 Gb/s single-HCA → 161 Gb/s with both HCAs + `NCCL_IB_MERGE_NICS=1` (+64%)**.

Changes:
- `.env.dspark.example`: dual-HCA placeholders (`NCCL_IB_HCA`/`NCCL_SOCKET_IFNAME` as comma pairs), `NCCL_IB_MERGE_NICS=1`, `NCCL_IB_GID_INDEX=3` with the RoCEv2 sysfs verification one-liner (`/sys/class/infiniband/<hca>/ports/1/gid_attrs/types/3`), and the `ibdev2netdev` mapping hint.
- `DEFAULT-CONFIG.md`: a note beside the env block with the measured numbers, plus two adjacent traps we hit: pre-2026-04 BIOS wires the second controller at Gen5 x2 (fix via `fwupdmgr` before measuring anything), and GDR 0 on GB10 remains the decode ceiling after this. Framed explicitly as for back-to-back QSFP pairs — your CRS812 switched fabric may leave the second NIC unused on purpose, so the note stays out of the main table.

Dogfooded: this is the live configuration on our pair since 2026-08-03; the measured numbers are from bring-up validation with nccl-tests before any weights were copied.
