### PR TITLE
fix(compose): log to journald so container generations keep their logs

### DIFF
--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -6,6 +6,23 @@ services:
     restart: unless-stopped
     shm_size: "64gb"
 
+    # Log to the journal, not to the container's json-file.
+    #
+    # stop-deepseek-v4-flash-dspark.sh runs `docker compose ... down`, which
+    # removes the containers -- and json-file logs die with the container they
+    # belong to. By the time you know you want a log, the container that held
+    # it is gone. journald keeps the lines after the container is removed.
+    #
+    # Retrieve with (the -a matters -- vLLM's progress bars emit carriage
+    # returns, and without -a journalctl renders them as "[108B blob data]"):
+    #   journalctl -a CONTAINER_TAG=dspark-vllm-dspark-recipe-vllm-dspark-1
+    #
+    # `docker logs` keeps working under this driver, so no workflow changes.
+    logging:
+      driver: journald
+      options:
+        tag: "dspark-vllm-{{.Name}}"
+
     ulimits:
       memlock: -1
       stack: 67108864


### PR DESCRIPTION

## Problem

`docker rm` destroys `json-file` container logs, and this recipe's own
`stop-deepseek-v4-flash-dspark.sh` runs `docker compose ... down` on both nodes — so every
stop/start cycle removes the containers and takes their logs with them.

On our 2x DGX Spark pair, docker's restart journal showed ~12 container replacements in 5 days.
An unknown subset of those were genuine engine deaths (several were deliberate restarts), and
we can no longer tell which, because none of them left retrievable server-side evidence. The
first death we could actually analyse (2026-08-17) kept its 16k-line log only because we
manually copied it out of the container before restarting.

That is the failure mode: by the time you know you want the log, the container that held it is
gone.

## Change

```yaml
    logging:
      driver: journald
      options:
        tag: "dspark-vllm-{{.Name}}"
```

Retrieval:

```bash
journalctl -a CONTAINER_TAG=dspark-vllm-dspark-recipe-vllm-dspark-1
```

⚠️ **`-a` matters.** vLLM's progress bars emit carriage returns; without `-a`, journalctl
renders them as `[108B blob data]` and the log looks broken.

`docker logs` keeps working under this driver, so no workflow changes.

## Why not `docker logs` alone

`docker logs` reads the json-file. The whole failure mode is that the file is gone by the time
you look. Any fix that keeps logs inside the container lifecycle has the same hole.

## Verified

- `/var/log/journal` is present and persistent on both our DGX Sparks as shipped (3.4G / 3.3G).
  n=2 — we have not checked DGX OS generally.
- Driver live with the tag: `docker inspect … '{{.HostConfig.LogConfig}}'` →
  `journald map[tag:dspark-vllm-{{.Name}}]`.
- **Log lines survive container recreation** — verified today: the tag's journal holds 171,326
  lines going back to 2026-08-18, and the container that wrote most of them no longer exists.
  Running on our pair since 2026-08-18, through a full recipe update and image rebuild.
- No rate-limit suppression notices observed (systemd default is 10000 msgs / 30 s per service).

**Scope of that claim:** this fixes log *retention*, not verbosity. We have had one wedge
(2026-08-13) where the engine wrote no traceback at all — journald would not have helped there.
No crash has occurred since we enabled it, so we have verified that log lines survive recreation,
not that a traceback has survived a crash.

## Scope

Compose only. No change to the vLLM invocation, the image, or any env var.

---

Re-verified at time of filing: journal for the tag holds **171,326 lines back to
2026-08-18 00:49**, while the currently-running container was created
**2026-08-20 18:48** — i.e. the lines outlived the container that wrote them.
`/var/log/journal` 3.4G / 3.3G on the two nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133HsRa6EaDj8UwiXbJqdKQ
