### PR TITLE
fix(nvfp4): widen the decode-dispatch condition to nvfp4_ds_mla (completes the b12x sweep)

### DIFF
--- a/patches/official-main-b12x-nvfp4-python.patch
+++ b/patches/official-main-b12x-nvfp4-python.patch
@@ -233,6 +233,15 @@ index 19381ef..aefa424 100644
              # Reserve workspace during initialization
              assert vllm_config is not None and vllm_config.model_config is not None
              prefill_workspace_size = get_prefill_workspace_size(
+@@ -1010,7 +1011,7 @@ class FlashMLASparseImpl(SparseMLAAttentionImpl[FlashMLASparseMetadata]):
+         assert self.topk_indices_buffer is not None
+         topk_indices = self.topk_indices_buffer[:num_actual_toks]
+ 
+-        use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
++        use_fp8_cache = self.kv_cache_dtype in ("fp8_ds_mla", "nvfp4_ds_mla")
+ 
+         if not use_fp8_cache:
+             attn_out = self._forward_bf16_kv(
 diff --git a/vllm/v1/kv_cache_interface.py b/vllm/v1/kv_cache_interface.py
 index 323b1e7..d14637b 100644
 --- a/vllm/v1/kv_cache_interface.py


### PR DESCRIPTION
Relates to #22.

## Problem

`patches/official-main-b12x-nvfp4-python.patch` already widens the sibling conditions to accept
`nvfp4_ds_mla` — the dtype allowlist, the `cache_config.cache_dtype` assignments,
`get_kv_quant_mode`, the 584-byte page-size branch, the prefill workspace reservation. Sixteen
occurrences.

One line was missed. In `flashmla_sparse.py` the decode path still gates on an exact match:

```python
# vllm 0.21.1rc1.dev339+g1967a5627bc3, flashmla_sparse.py:1014, stage-c image
use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
```

The recipe's default is `--kv-cache-dtype ${KV_CACHE_DTYPE:-nvfp4_ds_mla}`
(docker-compose.dspark.yml:154), so on the **default configuration** this evaluates False and
decode takes `_forward_bf16_kv` instead of the fp8 path.

Note that the *same file*, four hunks earlier in the same patch, already asserts

```python
assert kv_cache_dtype in ("fp8_ds_mla", "nvfp4_ds_mla")
```

so `nvfp4_ds_mla` reaches this line legitimately and then falls through silently rather than
erroring.

## Change

One hunk added to `official-main-b12x-nvfp4-python.patch`, next to the fifteen sibling
conditions it matches:

```
-        use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
+        use_fp8_cache = self.kv_cache_dtype in ("fp8_ds_mla", "nvfp4_ds_mla")
```

We ran this as a start-time `sed` from 2026-08-13 to 2026-08-20 and have sent it as a patch hunk
instead, because the `sed` form has a real defect: it prints `fixed-condition count: N` but
nothing fails at `N=0`. If a future vLLM bump drifts that source line, the `sed` silently stops
matching and the fix silently reverts. The patch file fails loudly instead, which is the
behaviour you want here.

## How the hunk was validated

- context extracted from the shipped stage-c image, not from memory:
  `/opt/env/lib/python3.12/site-packages/vllm/v1/attention/backends/mla/flashmla_sparse.py:1014`
- `git apply --check` against that exact file: applies clean
- negative control 1 — re-applying to the already-patched file: **rejected**
- negative control 2 — one character corrupted in a context line: **rejected**
- whole patch file re-parsed with `git apply --numstat` after the edit: well-formed, 9 files
- negative control 3 — corrupted hunk line-count in the new hunk: **rejected**

Line numbering: the hunk header is `@@ -1010,7 +1011,7 @@`. The `+1` is the single line this
patch adds at the allowlist near line 93; the 584 hunk is net zero.

## What we verified, and what we did not

Verified:
- the unpatched line is exactly as quoted, in the shipped stage-c image
- the widened condition imports cleanly (`loaded module has fix: True`, both nodes)
- `fp8_ds_mla` serving is unharmed with it applied

**Not verified — and we want to be plain about this: we never exercised the patched branch.**
We serve `fp8_ds_mla`, which the unpatched condition already matches, so for us this is a no-op.
We never booted `nvfp4_ds_mla` with the fix applied and never measured long-context decode on
that lane. If you ask whether we observed the recovery reported in #22, the honest answer is no.

We are **not** attaching a performance number. We had one in an earlier draft and removed it: the
KV-pool figures in our logs come from the fp8 lane during an outage that also raised max-model-len
from 500K to 1M, so they say nothing about this change. `use_fp8_cache` selects the decode kernel;
the KV layout is 584 B/token for both dtypes, so it cannot move pool size at all.

## Why we're sending it rather than keeping it

We dropped it locally when we merged your last 16 commits, because it is a no-op on the lane we
serve. It is not a no-op on yours — `nvfp4_ds_mla` is the recipe default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133HsRa6EaDj8UwiXbJqdKQ
