### PR TITLE
fix(compose): pass NCCL_IB_MERGE_NICS through to the container

### DIFF
--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -107,6 +107,12 @@ services:
       NCCL_IB_DISABLE: "${NCCL_IB_DISABLE:-0}"
       NCCL_IB_HCA: "${NCCL_IB_HCA}"
       NCCL_SOCKET_IFNAME: "${NCCL_SOCKET_IFNAME}"
+      # Without this pass-through, NCCL_IB_MERGE_NICS=1 in .env.dspark reaches
+      # the launcher's shell but NEVER the container: compose has no env_file,
+      # so it delivers only the names listed here. The .env.dspark.example sets
+      # it and DEFAULT-CONFIG.md credits it with 98 -> 161 Gb/s busbw, but the
+      # container has always come up with it unset.
+      NCCL_IB_MERGE_NICS: "${NCCL_IB_MERGE_NICS:-}"
       # The base image bakes GLOO_SOCKET_IFNAME/TP_SOCKET_IFNAME for the
       # author's NIC. On any other host those interfaces do not exist and
       # rank init dies in ProcessGroupGloo (gloo/transport/tcp/device.cc).


### PR DESCRIPTION

## Problem

`.env.dspark.example` sets it:

```
# ...list both HCAs here, and set NCCL_IB_MERGE_NICS=1.
NCCL_IB_MERGE_NICS=1
```

`DEFAULT-CONFIG.md:163` credits it with the headline fabric result:

> 98 Gb/s single vs **161 Gb/s** with both HCAs listed and `NCCL_IB_MERGE_NICS=1`

But `docker-compose.dspark.yml` has no `environment:` entry for it and no `env_file:`, so compose
delivers only the names it lists. The launcher's `set -a; source .env.dspark; set +a` puts the
variable in the *launcher's* shell, and it stops there. The engine has always come up with it
unset.

This is the same failure class as `DSPARK_MODEL=` on the command line being silently ignored:
**a variable you did not confirm arrived is a variable you did not set.**

## How I know it isn't reachable some other way

I checked all 66 variables `.env.dspark.example` sets, counting a variable as deliverable if the
compose interpolates it (`${VAR}` / `${VAR:-}`) **or** any `*.sh` in the repo dereferences it.

**`NCCL_IB_MERGE_NICS` is the only one of the 66 that nothing dereferences.** The one other
mention in the repo hardcodes it to `0` in an unrelated lane script
(`scripts/ds4lane_anemll.sh:98`), which is a literal, not a read.

Harness had negative controls: `NCCL_IB_HCA`, `WORKER_HF_CACHE`, `MTP_NUM_TOKENS` and
`NCCL_IB_GID_INDEX` must each come back reachable (they do, including `WORKER_HF_CACHE` which is
shell-only and `NCCL_IB_GID_INDEX` which is compose-only), and an invented variable name must come
back flagged (it does). A first version of the sweep searched only `scripts/` and missed the
root-level launchers; the negative controls are what caught it.

## Change

```yaml
      NCCL_IB_MERGE_NICS: "${NCCL_IB_MERGE_NICS:-}"
```

Defaulted empty, so unset stays unset and nothing changes for anyone on a switched fabric or a
single-HCA box.

Verified at the point of effect, not in the file: `docker compose config` against the real
`.env.dspark` now resolves `NCCL_IB_MERGE_NICS: "1"`, where before the key was absent entirely.

## What this cost us, and what we still can't confirm

We spent an evening measuring the dual-HCA claim on a 2x DGX Spark back-to-back pair and got
"the second rail does nothing" — because the variable was never arriving. That result was wrong
and we retracted it. The three settings together (both HCAs, `NCCL_IB_MERGE_NICS=1`,
`NCCL_IB_GID_INDEX=3`) took iperf3 `-P 8` from 111 to ~184 Gb/s (n=3).

Two things we are **not** claiming:

1. **We have no `nccl-tests busbw` number.** Ours is iperf3 TCP, yours is busbw. They are not
   comparable and we are not asserting we reproduced 98 -> 161.
2. **We have an unresolved decode question.** On our workload the merged dual-rail config bought
   ~2.9% on cold long-context prefill (49.93 -> 48.48 s median, n=3, non-overlapping) but our
   pinned acceptance probe came back ~6.5% lower on decode tok/s afterwards (46.4 -> 43.4 median).
   Three fabric settings changed at once, so we cannot attribute that yet, and thermals were
   *cooler* during the slower run rather than warmer. We are running the controlled A/B and will
   report back either way. **Flagging it here because if it holds up, `NCCL_IB_MERGE_NICS=1` may
   be the right default for prefill-heavy work and the wrong one for decode-heavy work** — and
   nobody can currently observe that either way, since the variable never arrives.

The fix stands regardless of how that lands: right now the recipe cannot deliver a setting its own
documentation is built on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133HsRa6EaDj8UwiXbJqdKQ
