### PR TITLE
docs: dual-HCA — don't pin NCCL_IB_GID_INDEX (GID drift, #38) + netplan/MTU/JIT-retune pitfalls

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -28,9 +28,15 @@ HEADLESS=
 NCCL_IB_HCA=rocepXsYfZ,rocePWpXsYfZ
 NCCL_SOCKET_IFNAME=enpXsYfZnpN,enPWpXsYfZnpN
 NCCL_IB_MERGE_NICS=1
-# GID 3 = RoCEv2. Verify per port before serving:
-#   cat /sys/class/infiniband/<hca>/ports/1/gid_attrs/types/3   -> "RoCE v2"
-NCCL_IB_GID_INDEX=3
+# Do NOT pin NCCL_IB_GID_INDEX (changed 2026-08-21, issue #38 field report):
+# GID table indexes DRIFT when interface events reshuffle the table (observed
+# 3->4 within 30 minutes with both HCAs up). A pinned index that was correct at
+# write time later fails on ONE HCA only ("ibv_modify_qp failed with 61") and
+# hangs the TP handshake silently after model load. Modern NCCL selects the
+# RoCEv2/IPv4 GID per device on its own. If your compose maps this variable,
+# map it to null — an EMPTY STRING parses as 0, which selects the fe80
+# link-local GID and is worse than the pin.
+# NCCL_IB_GID_INDEX=3   # <- do not re-enable; kept for archaeology
 NCCL_CROSS_NIC=1
 
 # Caches / model

--- a/DEFAULT-CONFIG.md
+++ b/DEFAULT-CONFIG.md
@@ -154,21 +154,25 @@ TORCH_CUDA_ARCH_LIST=12.1a  FLASHINFER_CUDA_ARCH_LIST=12.1a  FLASHINFER_DISABLE_
 TILELANG_CLEANUP_TEMP_FILES=1  DG_JIT_USE_NVRTC=0  DG_JIT_NVCC_COMPILER=/opt/env/bin/nvcc
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 NCCL_NET=IB  NCCL_IB_DISABLE=0  NCCL_IB_HCA=rocep1s0f0  NCCL_SOCKET_IFNAME=enp1s0f0np0
-NCCL_IB_GID_INDEX=3  NCCL_CROSS_NIC=1  NCCL_CUMEM_ENABLE=0  NCCL_IGNORE_CPU_AFFINITY=1
+NCCL_CROSS_NIC=1  NCCL_CUMEM_ENABLE=0  NCCL_IGNORE_CPU_AFFINITY=1  # NCCL_IB_GID_INDEX: unset on purpose — see dual-HCA note
 NCCL_DEBUG=WARN  NCCL_NVLS_ENABLE=0
 ```
 
 > **Dual-HCA note (direct QSFP pairs):** the GB10 QSFP port is TWO virtual NICs
 > (2x PCIe x4). With only one configured, NCCL runs at ~half the port: measured
 > 98 Gb/s single vs **161 Gb/s** with both HCAs listed and `NCCL_IB_MERGE_NICS=1`
-> (+64% busbw, nccl-tests). Both interfaces need an IP (separate subnets) and MTU
-> 9000; map names with `ibdev2netdev`; confirm GID 3 is RoCE v2 via
-> `/sys/class/infiniband/<hca>/ports/1/gid_attrs/types/3`. Two related traps:
-> pre-2026-04 BIOS wires the second controller at Gen5 x2 (half bandwidth -
-> update via `fwupdmgr` first), and GB10 has no GPUDirect RDMA (GDR 0), which is
-> the remaining decode ceiling. On a switched fabric (like the CRS812 setup
-> above) the second NIC may be deliberately unused - this note is for
-> back-to-back QSFP pairs chasing interconnect-bound decode.
+> (+64% busbw, nccl-tests). Both interfaces need an IP (separate subnets, persisted via a
+> netplan drop-in on DGX OS — `nmcli` profiles live in /run and evaporate on
+> reboot) and MTU 9000 on BOTH ends (a firmware capsule reboot has been seen
+> resetting one side to 1500 → `IBV_WC_RETRY_EXC_ERR(12)` on large transfers);
+> map names with `ibdev2netdev`. **Leave `NCCL_IB_GID_INDEX` unset** — GID
+> table indexes drift when interface events reshuffle the table (3→4 within
+> 30 min observed), and a pinned index hangs the TP handshake silently on one
+> HCA; modern NCCL picks the RoCEv2/IPv4 GID per device (issue #38 field
+> report, credit @Lollorosso2 — also measured +8% single-stream / 135 tok/s
+> @c6 with the merge on a second GB10 rig). First boot after ANY NCCL topology
+> change re-runs JIT tuning (~36 min observed) — a watchdog that gives up at
+> 20 min will "confirm" a hang that isn't one.
 
 ```
 HF_HUB_OFFLINE=1  TRANSFORMERS_OFFLINE=1  HF_HUB_DISABLE_XET=1  HF_HOME=/cache/huggingface  VLLM_CACHE_ROOT=/cache/huggingface/vllm-cache


### PR DESCRIPTION
Folds @Lollorosso2's #38 field report back into the dual-HCA doc, plus validation from the reference pair.

**The correction:** the doc recommended `NCCL_IB_GID_INDEX=3` (verified-at-write against `gid_attrs`). #38 showed GID table indexes **drift** when interface events reshuffle the table (3→4 within 30 min observed) — a pinned index then fails on ONE HCA only (`ibv_modify_qp` err 61) and hangs the TP handshake silently after model load. Modern NCCL selects the RoCEv2/IPv4 GID per device; the doc now says **leave it unset**, with the compose caveat that matters: map the variable to `null` — an empty string parses as 0 = the fe80 link-local GID, which is worse than the pin.

**Also folded from the report:** persist the second NIC via a netplan drop-in on DGX OS (nmcli profiles live in /run), re-verify MTU 9000 both ends after firmware capsule reboots (`IBV_WC_RETRY_EXC_ERR(12)` signature), and expect ~36 min of JIT retuning on the first boot after any NCCL topology change — a 20-minute watchdog will 'confirm' a hang that isn't one.

**Validated on the reference pair today (2026-08-21):** the same latent pin was found live in our `.env.dspark` (both nodes), removed with the compose-null pattern, and the unpinned boot came up clean — start script exit 0, `NCCL_IB_GID_INDEX` absent from container env, zero NCCL warnings, TP generation verified.

Files: `.env.dspark.example` (pin retired with rationale), `DEFAULT-CONFIG.md` (env line + dual-HCA note rewritten with all three pitfalls, credit in-text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYBRsZkZKH3aV1tDwkmS8H