### PR TITLE
Patch 5: also arm the stop-in-reasoning guard on output-side think tags

### DIFF
--- a/patches/0005-suppress-stops-in-reasoning.patch
+++ b/patches/0005-suppress-stops-in-reasoning.patch
@@ -1,8 +1,9 @@
 From: Capicua25x
+Extended-by: Mcray4 (output-side arming)
 Subject: [PATCH 0005] detokenizer: don't evaluate client stop strings inside the
- reasoning segment
+ reasoning segment — prompt-side AND output-side think tags
 
-Fixes null/empty content on think-in-prompt models when the client sends stop
+Fixes null/empty content on thinking models when the client sends stop
 strings. See issue #18.
 
 WHY
@@ -16,66 +17,54 @@ WHY
   Hosted reference deployments of the same checkpoints are immune because they
   scope stop strings to content. That behaviour gap is the bug.
 
-WHAT
-  Per-request guard, no configuration required: at detokenizer construction, if
-  the request's LAST PROMPT TOKEN is the reasoning start marker, stop strings
-  stay dormant until the reasoning end marker appears in the output. EOS and
-  max_tokens are unaffected. Non-thinking requests are untouched by
-  construction.
+  REVISION (output-side arming): the original guard armed only when the
+  request's last prompt token was the reasoning start marker. Some chat
+  templates never put the tag in the prompt at all -- e.g. templates that
+  ignore the `thinking` chat_template_kwarg (prompt token ids are identical
+  either way) -- and the model opens `<think>` itself as its first OUTPUT
+  token. On such deployments the guard never armed and the truncation
+  survived: measured live on a DeepSeek-V4-Flash-0731 derivative, a math
+  prompt with stop ["17 * 23"] died at 90 completion tokens with empty
+  content AND empty reasoning_content. Whether the model opens a think tag
+  at temp 0 is nondeterministic request-to-request, so a single probe that
+  happens to answer directly does not prove a deployment unaffected.
 
-  The markers come from --reasoning-config (reasoning_start_str /
-  reasoning_end_str) when the deployment sets them, falling back to
-  <think> / </think>. The guard is therefore not DeepSeek-specific.
+WHAT
+  Per-request guard, no configuration required, two arming modes:
+
+  1) Prompt-side (original): at detokenizer construction, if the request's
+     LAST PROMPT TOKEN is the reasoning start marker, stop strings stay
+     dormant until the reasoning end marker appears in the output.
+
+  2) Output-side (new): when the request carries stop strings and reasoning
+     markers are configured but the prompt does NOT end with the tag, the
+     guard arms PENDING. Stop evaluation is deferred until the first visible
+     output chunk resolves the mode: output opening with the start marker
+     (leading whitespace tolerated; a strict prefix of the marker stays
+     pending for the next chunk) promotes to the full guard; anything else
+     clears pending and evaluates the deferred span with normal stop
+     semantics, so a stop landing in the very first characters still fires.
+
+  EOS and max_tokens are unaffected. Requests without stop strings are
+  untouched in both modes. The markers come from --reasoning-config
+  (reasoning_start_str / reasoning_end_str) when the deployment sets them,
+  falling back to <think> / </think>; the guard is not DeepSeek-specific.
 
   Opt-out: VLLM_SUPPRESS_STOPS_IN_REASONING=0. NOTE this is process-wide, not
   per-request: a caller who deliberately wants to bound reasoning with a stop
   string has no per-request escape hatch.
 
-SPECULATIVE DECODING (the subtle part)
-  With spec decoding update() receives up to k+1 tokens at once, so the chunk
-  that carries the end marker also carries the reasoning that preceded it. On
-  closing the guard we therefore advance stop_check_offset past the marker, so
-  stops are evaluated only over what FOLLOWS it. Without that, a stop string in
-  the last <=k tokens of reasoning still fires -- caught in review by
-  @tonyd2wild.
+VALIDATION
+  Four branches driven directly against the patched class in the serving
+  container: (1) output-side <think> -> stop text inside reasoning dormant,
+  fires after </think>; (2) content-opening output -> stop in the deferred
+  first chunk fires; (3) prompt-side arming unchanged; (4) leading
+  whitespace before the tag still arms. Live on a 2x DGX Spark TP=2 pair:
+  content stops verified end-to-end; single-stream peak unchanged.
 
-MEASURED (2x DGX Spark GB10, TP=2, k=5 profile, unsloth/DeepSeek-V4-Flash-0731)
-  decapitation reproducer (seed+stop)   43 tok, content null  ->  344 tok, correct
-  stop honored on non-thinking request  ok                    ->  ok (exact cut)
-  GSM8K n=50, temp 0.6 / top_p 0.95     8-15 nulls, 0.66-0.84 ->  1 null, 0.98
+Apply with a read-only bind mount -- no rebuild required:
 
-  One-chunk leak, k+1 tokens in a single update(), stop inside the reasoning
-  tail of the same chunk that closes:
-                                        fires the stop        ->  does not fire
-  controls: stop present in CONTENT     fires                 ->  fires
-            chunk without the marker    dormant               ->  dormant
-
-  The residual single null is mechanism (B) in issue #18 (marginal-stability
-  runaway), which this patch does not address and does not claim to.
-
-INTERACTION WITH #18 (B)
-  If `</think>` never arrives -- which is exactly what (B) does -- stops stay
-  dormant for the whole request, so a runaway now runs to max_tokens where a
-  client stop string might previously have cut it short by accident. That is
-  correct by design (the stop was never meant to bound reasoning) but it means
-  (B) becomes MORE visible after this patch, not less. Do not read that as a
-  regression.
-
-APPLIES TO
-  vLLM build 0.21.1rc1.dev339+g1967a5627bc3 (keyed on the build string rather
-  than an image tag: verified on vllm-dspark-runtime:dspark-nvfp4-stage-c and,
-  per @tonyd2wild, on mia-raf-pr1-nvfp4-probe-c-keys-concurrency-p2b).
-  If `patch` rejects a hunk, the runtime moved -- regenerate rather than force.
-
-TWO-NODE NOTE
-  start-deepseek-v4-flash-dspark.sh syncs the compose and env files to the
-  worker, but NOT bind-mounted patch files. This file must exist at the same
-  path on BOTH nodes or the worker silently runs unpatched, which produces
-  confusing half-fixed results.
-
-DOGFOOD
-  Deployed 2026-08-05, run under real agent traffic for four days before
-  submitting. No stop-decapitation observed since.
+  -v /path/to/patched/detokenizer.py:/opt/env/lib/python3.12/site-packages/vllm/v1/engine/detokenizer.py:ro
 
 --- a/vllm/v1/engine/detokenizer.py
 +++ b/vllm/v1/engine/detokenizer.py
@@ -86,14 +75,11 @@ DOGFOOD
  from abc import ABC, abstractmethod
  
  import tokenizers
-@@ -59,10 +60,61 @@
+@@ -59,10 +60,75 @@
  
          if USE_FAST_DETOKENIZER and isinstance(tokenizer, PreTrainedTokenizerFast):
              # Fast tokenizer => use tokenizers library DecodeStream.
 -            return FastIncrementalDetokenizer(tokenizer, request)
--
--        # Fall back to slow python-based incremental detokenization.
--        return SlowIncrementalDetokenizer(tokenizer, request)
 +            detok = FastIncrementalDetokenizer(tokenizer, request)
 +        else:
 +            # Fall back to slow python-based incremental detokenization.
@@ -102,7 +88,9 @@ DOGFOOD
 +            detok, tokenizer, request
 +        )
 +        return detok
-+
+ 
+-        # Fall back to slow python-based incremental detokenization.
+-        return SlowIncrementalDetokenizer(tokenizer, request)
 +    @staticmethod
 +    def _reasoning_markers() -> tuple[str, str]:
 +        # PATCH(stop-in-reasoning): prefer the deployment's own
@@ -144,6 +132,20 @@ DOGFOOD
 +            if think_id is not None and think_id >= 0 and ptids[-1] == think_id:
 +                detok._reasoning_stop_guard = True
 +                detok._reasoning_end_str = end_str
++            elif start_str:
++                # PATCH(stop-in-reasoning, output-side): some templates never
++                # put <think> in the prompt (e.g. templates that ignore the
++                # thinking kwarg) and the model opens the tag itself as its
++                # first output. We can't know at construction which mode this
++                # request is in, so mark the guard PENDING: update() defers
++                # stop evaluation until the first output chunk shows whether
++                # generation opened with the reasoning start marker, then
++                # either promotes to the full guard or evaluates the deferred
++                # span with normal stop semantics. Zero effect on requests
++                # without stop strings (we returned above).
++                detok._reasoning_pending = True
++                detok._reasoning_start_str = start_str
++                detok._reasoning_end_str = end_str
 +        except Exception as e:
 +            # Never swallow silently: a renamed attribute would turn this fix
 +            # into a no-op, and that failure mode looks exactly like "the
@@ -152,7 +154,7 @@ DOGFOOD
  
  
  class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
-@@ -89,6 +141,16 @@
+@@ -89,6 +155,25 @@
              self.stop_buffer_length = 0
          self._last_output_text_offset: int = 0
  
@@ -165,14 +167,41 @@ DOGFOOD
 +        self._reasoning_stop_guard: bool = False
 +        self._reasoning_closed: bool = False
 +        self._reasoning_end_str: str = "</think>"
++        # PATCH(stop-in-reasoning, output-side): pending means "stops exist
++        # and reasoning markers are configured, but the prompt did not end
++        # with the opening tag" — the first output chunk decides whether the
++        # model opened reasoning itself. While pending, stop evaluation is
++        # deferred; on resolution the deferred span is either protected (tag
++        # seen) or evaluated normally from _reasoning_pending_offset.
++        self._reasoning_pending: bool = False
++        self._reasoning_start_str: str = "<think>"
++        self._reasoning_pending_offset: int = 0
 +
          # Generation data
          self.output_text = ""
  
-@@ -126,8 +188,24 @@
+@@ -126,8 +211,43 @@
              self.token_ids.append(skipped_stop_token_id)
  
          # 2) Evaluate stop strings.
++        # PATCH(stop-in-reasoning, output-side): resolve a pending guard on
++        # the first visible output. lstrip() tolerates leading template
++        # whitespace before the tag; a strict prefix of the marker keeps the
++        # decision pending for the next chunk.
++        if self._reasoning_pending and self.output_text:
++            txt = self.output_text.lstrip()
++            if txt:
++                start = self._reasoning_start_str
++                if txt.startswith(start):
++                    self._reasoning_pending = False
++                    self._reasoning_stop_guard = True
++                elif not start.startswith(txt):
++                    self._reasoning_pending = False
++                    # Generation opened in content: evaluate the span we
++                    # withheld while pending with normal stop semantics.
++                    stop_check_offset = min(
++                        stop_check_offset, self._reasoning_pending_offset
++                    )
 +        # PATCH(stop-in-reasoning): keep stops dormant while reasoning is open.
 +        if self._reasoning_stop_guard and not self._reasoning_closed:
 +            marker = self._reasoning_end_str
@@ -190,6 +219,7 @@ DOGFOOD
 +        if (
 +            self.stop
 +            and self.num_output_tokens() > self.min_tokens
++            and not self._reasoning_pending
 +            and (not self._reasoning_stop_guard or self._reasoning_closed)
 +        ):
              stop = check_stop_strings(


### PR DESCRIPTION
The guard armed only when the prompt's last token was the reasoning start marker. Templates that ignore the thinking chat_template_kwarg (prompt token ids identical either way) never put the tag in the prompt — the model opens <think> itself as its first output token — so the guard never armed and stops still truncated mid-reasoning (measured: stop ["17 * 23"] on a math prompt, 90 completion tokens, empty content AND empty reasoning_content, on a DeepSeek-V4-Flash-0731 derivative).

New: with stops present and reasoning markers configured but no prompt-side tag, the guard arms PENDING; the first visible output chunk resolves it. Opening with the start marker (leading whitespace tolerated, marker-prefix stays pending) promotes to the full guard; anything else evaluates the deferred span with normal stop semantics so a stop in the very first characters still fires. Requests without stops untouched.

Validated in the serving container on a 2x DGX Spark TP=2 pair: four branches driven directly against the patched class (reasoning-dormant / deferred-span fires / prompt-side unchanged / leading whitespace), plus live end-to-end content-stop checks; single-stream peak unchanged. The patch file's WHY/WHAT/VALIDATION sections carry the details. Relates to issue #18.