### PR TITLE
Native vision: deploy DeepSeek-V4-Flash-Vision-Exp on 2x DGX Spark (day-0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ reference implementation, explicitly "rather than a production serving engine."
 
 Running the repo's existing **validated agent-serving profile** — `MAX_MODEL_LEN=1500000`,
 `MAX_NUM_SEQS=12`, `GPU_MEMORY_UTILIZATION=0.85`, `MTP_NUM_TOKENS=3` — with the vision port
-on top. **Use `k=3`, not the 0731 recipe's `k=5`:** this release moved
-`num_nextn_predict_layers` from 1 to 3, and carrying k=5 across measurably underperforms.
+on top. **Use `k=5`, same as the 0731 recipe, with Patch 4 mounted.** An earlier version of this branch said k=3: that A/B was measured without the Patch 4 `spec-dspark.py` mount, which silently halves the draft's acceptance (see `vision-exp/README.md`, [#48](../../issues/48)). With Patch 4 present, k=5 wins count-to-300 by a third and code is neutral. This release moved `num_nextn_predict_layers` from 1 to 3, which is why the drafter deserves a second look, but not at k=3.
 
 **→ [Full guide, the twelve blockers, and the port: `vision-exp/`](vision-exp/README.md)**
 
@@ -48,7 +47,7 @@ Text-only `0731` is unchanged and still fully supported — every patch is guard
 >
 > **Covers all three checkpoints:**
 > - **`deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`** (2026-08-31, multimodal) — **native vision,
->   55.9 tok/s text.** See [`vision-exp/`](vision-exp/README.md).
+>   55.9 tok/s text, measured before the Patch 4 mount was added to the vision launcher; with Patch 4, #48 measures 85.5 count / 49.9 code / 29.5 prose.** See [`vision-exp/`](vision-exp/README.md).
 > - **`deepseek-ai/DeepSeek-V4-Flash-0731`** (official release) — **78 tok/s peak, ~55 typical.**
 >   Requires [Patch 4](patches/0004-dspark-shared-expert-gate-up-proj.patch); without it you get
 >   roughly half speed at unchanged output quality. **Start here →

--- a/README.md
+++ b/README.md
@@ -20,9 +20,15 @@ reference implementation, explicitly "rather than a production serving engine."
 
 | | measured, 2x GB10, TP2, temperature 0 |
 |---|---|
-| Text, count-to-100 | **55.9 tok/s** median · 58.0 peak |
-| DSpark acceptance | 0.628 · **4.14** mean accepted length (k=5) |
+| **KV cache pool** | **2,904,519 tokens** (18.18 GiB) |
+| **Context** | **1,500,000** per request · max concurrency **1.94x** |
 | Vision, 336x336 + 26-token answer | **1.03 s** end to end |
+| Image understanding | colour **and** position correct, both orientations |
+
+Running the repo's existing **validated agent-serving profile** — `MAX_MODEL_LEN=1500000`,
+`MAX_NUM_SEQS=12`, `GPU_MEMORY_UTILIZATION=0.85`, `MTP_NUM_TOKENS=3` — with the vision port
+on top. **Use `k=3`, not the 0731 recipe's `k=5`:** this release moved
+`num_nextn_predict_layers` from 1 to 3, and carrying k=5 across measurably underperforms.
 
 **→ [Full guide, the twelve blockers, and the port: `vision-exp/`](vision-exp/README.md)**
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,48 @@
 # DeepSeek V4 Flash (DSpark) on 2x DGX Spark — 1M context, NVFP4 KV
 
+## 🆕 2026-08-31 — now running **DeepSeek-V4-Flash-Vision-Exp**, with native vision
+
+DeepSeek released
+[**DeepSeek-V4-Flash-Vision-Exp**](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp)
+today — the first multimodal model in the V4 family. **It is deployed here the same day,
+on 2x DGX Spark at TP2, with real image input and DSpark speculative decoding intact.**
+
+```
+"Based on the image, the two colors are red and blue.
+ Red is on the left side. Blue is on the right side."
+```
+
+Not a sidecar and not a VLM proxy — the model's own 32-block ViT and aligner running
+inside vLLM. This needed a genuine port: vLLM's `DeepseekV4ForCausalLM` is the **text-only**
+class, and the vision checkpoint reports the *same* architecture string while carrying 316
+tensors vLLM has nowhere to put, so it fails to load at all. DeepSeek shipped only a
+reference implementation, explicitly "rather than a production serving engine."
+
+| | measured, 2x GB10, TP2, temperature 0 |
+|---|---|
+| Text, count-to-100 | **55.9 tok/s** median · 58.0 peak |
+| DSpark acceptance | 0.628 · **4.14** mean accepted length (k=5) |
+| Vision, 336x336 + 26-token answer | **1.03 s** end to end |
+
+**→ [Full guide, the twelve blockers, and the port: `vision-exp/`](vision-exp/README.md)**
+
+Two deviations from the reference are documented there and are **not** yet fixed —
+bidirectional attention inside image spans, and the new `bias_vl` modality-specific MoE
+routing bias. Both affect image quality, neither affects text. Read that section before
+quoting this against benchmarks.
+
+Text-only `0731` is unchanged and still fully supported — every patch is guarded on
+`vision_n_layers`, so the same files serve both checkpoints.
+
+---
+
 > Self-contained two-node DGX Spark recipe for serving DeepSeek-V4-Flash with vLLM
 > TP=2, DSpark speculative decoding, and an experimental `nvfp4_ds_mla` KV cache —
 > 1M-token calibrated context (pushed to 1.5M), clean under agent concurrency.
 >
-> **Covers both checkpoints:**
+> **Covers all three checkpoints:**
+> - **`deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`** (2026-08-31, multimodal) — **native vision,
+>   55.9 tok/s text.** See [`vision-exp/`](vision-exp/README.md).
 > - **`deepseek-ai/DeepSeek-V4-Flash-0731`** (official release) — **78 tok/s peak, ~55 typical.**
 >   Requires [Patch 4](patches/0004-dspark-shared-expert-gate-up-proj.patch); without it you get
 >   roughly half speed at unchanged output quality. **Start here →

--- a/vision-exp/README.md
+++ b/vision-exp/README.md
@@ -105,17 +105,37 @@ Each was a real error, in the order they surfaced:
 
 ## Measured (2x DGX Spark GB10, TP2, temperature 0)
 
+Running the repo's **validated agent-serving profile** — `MAX_MODEL_LEN=1500000`,
+`MAX_NUM_SEQS=12`, `GPU_MEMORY_UTILIZATION=0.85`, `MTP_NUM_TOKENS=3`,
+`draft_sample_method=probabilistic` — with the vision port on top.
+
 | | |
 |---|---|
-| Text, count-to-100 | **55.9 tok/s** median, 58.0 peak |
-| DSpark acceptance | 0.628 ratio, **4.14** mean accepted length (k=5, max 6) |
-| Vision, 336x336 + 26-token answer | **1.03 s** end to end |
-| Image block, 112x112 | 117 tokens · 168x168 → 143 · 336x336 → 129 |
+| **KV cache pool** | **2,904,519 tokens** (18.18 GiB) |
+| **Context** | **1,500,000** per request · max concurrency **1.94x** |
+| Vision, 112x112 image | correct on colour *and* side, both orientations |
+| Vision, 336x336 + 26-token answer | 1.03 s end to end |
+| Image block size | 112x112 → 117 tokens · 168x168 → 143 · 336x336 → 129 |
 
-Correctness spot-checks, temperature 0, both exactly right:
+KV pool is a **per-boot** figure, not a fixed property — this repo's own README records an
+11% swing between two boots of an identical config, because available KV memory on GB10
+varies with what else has touched unified memory.
+
+### Speculative depth: use k=3, not k=5
+
+This release changed `num_nextn_predict_layers` from **1 to 3**. Carrying the 0731 recipe's
+`num_speculative_tokens: 5` across measurably underperforms — at 1M/gmu 0.78 it gave
+accept ratio **0.542**, mean accepted length **3.71**, and **52.1 tok/s** on count-to-300.
+`MTP_NUM_TOKENS=3` is what the repo's validated profile already specifies, and it matches the
+checkpoint's predict-layer count.
+
+### Correctness spot-checks (temperature 0)
 
 - red-left / blue-right, 112x112 → *"Red is on the left side. Blue is on the right side."*
 - green-top / yellow-bottom, 168x168 → *"Green and Yellow. The split is: Horizontal. The color on top is: Green."*
+
+Different colours, different split axis, different image sizes — all correct, and the
+image-block token counts match the reference math.
 
 ## Known deviations from the reference — read before claiming parity
 
@@ -159,8 +179,13 @@ sudo rm -rf ~/.cache/vllm-dspark/modelinfos
 ```
 
 Everything from the base recipe is unchanged: `--kv-cache-dtype nvfp4_ds_mla`,
-`--block-size 256`, DSpark `num_speculative_tokens: 5`, `draft_sample_method: probabilistic`,
-patch 3, and the full NCCL/env block.
+`--block-size 256`, `draft_sample_method: probabilistic`, patch 3, and the full NCCL/env
+block. Use the validated agent-serving profile — **1.5M context, gmu 0.85, seqs 12, k=3**.
+
+> **gmu 0.78 vs 0.85:** `DEFAULT-CONFIG.md` warns that 0.80 "boots and passes smoke tests,
+> then dies under traffic" (issue #8) because DSpark allocates buffers on the *first real
+> request*. The validated agent profile uses **0.85** and is the one measured here; 0.78
+> is the conservative single-lane value and yields a much smaller pool (1,482,106 tokens).
 
 ## Prior art
 

--- a/vision-exp/README.md
+++ b/vision-exp/README.md
@@ -1,0 +1,174 @@
+# DeepSeek-V4-Flash-Vision-Exp on 2x DGX Spark — native vision, TP2, DSpark
+
+**Released 2026-08-31. Deployed here the same day, with working native image input.**
+
+This directory adds native multimodal support for
+[`deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp)
+to the DSpark vLLM runtime. Not a sidecar, not a VLM proxy — the model's own ViT and
+aligner running inside vLLM, with DSpark speculative decoding intact.
+
+```
+$ curl :8888/v1/chat/completions -d @image_request.json
+
+  "Based on the image, the two colors are **red** and **blue**.
+   *   **Red** is on the **left** side.
+   *   **Blue** is on the **right** side."
+```
+
+## Why this needed a port at all
+
+vLLM's `DeepseekV4ForCausalLM` is the **text-only** class. The Vision-Exp checkpoint
+reports the *same* `architectures` string but carries 316 extra tensors vLLM has no home
+for, so loading it dies immediately:
+
+```
+ValueError: There is no module or parameter named 'aligner' in DeepseekV4ForCausalLM
+```
+
+DeepSeek shipped only a reference implementation — its own `inference/README.md` says it is
+"a readable reference implementation rather than a production serving engine." There was no
+vLLM path to configure.
+
+## What's new in this checkpoint vs 0731
+
+Diffing the two configs, the language model is **identical** apart from three things:
+
+| | 0731 | Vision-Exp |
+|---|---|---|
+| vision keys | — | 10 (`vision_n_layers` 32, `vision_dim` 1024, patch 14, 2D RoPE, downsample 3) |
+| `num_nextn_predict_layers` | 1 | **3** (DSpark drafter is now 3 layers) |
+| `rms_norm_eps` | 1e-6 | 1e-20 |
+| `ffn.gate.*` | `weight`, `tid2eid` | `weight`, `tid2eid`, **`bias`**, **`bias_vl`** |
+
+That last row is the interesting one: a **modality-specific MoE routing bias**. `bias`
+applies to text tokens, `bias_vl` to image tokens — experts are chosen differently by
+modality. It appears on **all 43 layers**, including the 3 hash-routing layers that 0731
+left without any bias at all. No paper or model card documents it.
+
+## The port
+
+| file | what it does |
+|---|---|
+| `port/ds4v_vision.py` | The ViT (32 blocks, 2D RoPE, RMSNorm, gated MLP) + Aligner (pixel-shuffle ÷3 → 2-layer GELU MLP). Verbatim numerics from the checkpoint's `inference/vision.py`. Deliberately **not** TP-sharded — ~410M params, cheaper to replicate than to all-gather. |
+| `port/ds4v_mm.py` | vLLM multimodal plumbing: processing info, dummy inputs, and a custom processor. The checkpoint has no HF processor, so preprocessing (resize solver, patchify, N-layout block build) is ported from `inference/image_processor.py`. |
+| `port/patch_vision.py` | Idempotent patcher for vLLM's vendored `deepseek_v4/nvidia/model.py` — 11 anchored edits. |
+| `port/patch_registry.py` | Registers a multimodal architecture alias (see below). |
+| `ds4-vision-tp2.sh` | Launcher. Byte-for-byte the DEFAULT-CONFIG command plus the vision mounts and `--hf-overrides`. |
+
+Every patch is guarded on `vision_n_layers > 0`, so **text-only 0731 keeps its exact
+previous behaviour** through the same files.
+
+## Twelve things that had to be fixed
+
+Each was a real error, in the order they surfaced:
+
+1. **`no module or parameter named 'aligner'`** — registered ViT + Aligner + the four learned
+   embeddings (`image_start/end/newline/pad`) and taught the weights mapper their prefixes.
+2. **`KeyError: aligner.gate_up_proj.bias`** — vLLM's fused-MLP `stacked_params_mapping`
+   rewrites any `.w1`/`.w3` into `gate_up_proj`. The ViT MLP and the aligner legitimately use
+   `w1`/`w2`. Guard so they fall through to the generic loader.
+3. **`KeyError: layers.0.ffn.gate.e_score_correction_bias`** — the new per-layer gate bias,
+   including on hash-MoE layers vLLM explicitly skips ("hash MoE doesn't use
+   e_score_correction_bias" — true for 0731, no longer true here). Plus `bias_vl`.
+4. **`'DeepseekV4Config' object has no attribute 'image_token_index'`** — the DSpark proposer
+   expects the standard VLM field once the model reports multimodal. Published from the
+   tokenizer's `<｜deepseek_image｜>` id (129264).
+5. **`Target model does not have 'model' attribute`** — the proposer calls
+   `target_model.get_language_model()` then `.model`/`.lm_head`. Standard VLMs keep the tower
+   beside a separate `language_model`; here the ViT lives *inside* the decoder stack, so
+   `get_language_model()` returns `self`.
+6. **`is not a multimodal model`** — vLLM answers `is_multimodal_model` from a **static
+   architecture-name table**, never inspecting the class. `SupportsMultiModal` in the MRO is
+   not enough. Added a `DeepseekV4VForConditionalGeneration` alias in `_MULTIMODAL_MODELS`
+   pointing at the same class, selected via `--hf-overrides`. 0731 keeps the text entry.
+7. **Same error, still** — vLLM caches model inspection on disk in
+   `$VLLM_CACHE_ROOT/modelinfos/`, keyed by **module + class**. Both names resolve to the same
+   class, so the alias reused the stale pre-patch "text-only" entry. Clear `modelinfos/`
+   after changing model interfaces.
+8. **`IndexError: list index out of range` in `_merge_mm_kwargs`** — ragged per-image fields
+   must use `MultiModalFieldConfig.flat_from_sizes`, not `batched`. Same shape as
+   `deepseek_vl2.py`.
+9. **Processor received 0 images** — vLLM passes `mm_data['images']` (plural, HF convention);
+   reading `'image'` silently yielded nothing.
+10. **`0 prompt placeholders`** — vLLM sets `is_update_applied=True` on the text+mm path and
+    only *searches* the returned ids, so the placeholder must be expanded to the full block
+    **inside `_call_hf_processor`**. It is also the only place the position-dependent
+    `COMPRESS_PAD_TO` alignment can be expressed, since a replacement callable only gets
+    `item_idx`.
+11. **`mat1 and mat2 shapes cannot be multiplied (3x196 and 588x1024)`** — `flat_from_sizes`
+    hands back one concatenated tensor, not a per-image list; iterating it walked individual
+    14x14 patches into the patch embedder. Split on `num_patches`.
+12. **`DeepSeek V4 hash MoE routing requires input_ids`** — the first `num_hash_layers` MoE
+    layers route by **token id**, but vLLM's multimodal path passes `inputs_embeds` with
+    `input_ids=None`. Fixed with `requires_raw_input_tokens = True`, which keeps the raw ids
+    alongside the embeddings.
+
+## Measured (2x DGX Spark GB10, TP2, temperature 0)
+
+| | |
+|---|---|
+| Text, count-to-100 | **55.9 tok/s** median, 58.0 peak |
+| DSpark acceptance | 0.628 ratio, **4.14** mean accepted length (k=5, max 6) |
+| Vision, 336x336 + 26-token answer | **1.03 s** end to end |
+| Image block, 112x112 | 117 tokens · 168x168 → 143 · 336x336 → 129 |
+
+Correctness spot-checks, temperature 0, both exactly right:
+
+- red-left / blue-right, 112x112 → *"Red is on the left side. Blue is on the right side."*
+- green-top / yellow-bottom, 168x168 → *"Green and Yellow. The split is: Horizontal. The color on top is: Green."*
+
+## Known deviations from the reference — read before claiming parity
+
+Two, both quality-affecting and neither crash-causing. They are why this ships as a working
+deployment rather than a parity claim.
+
+**1. Bidirectional attention within image spans is not implemented.** The reference computes
+`get_image_visible()` and widens the sparse-attention window so tokens inside an
+`[IMAGE_START, IMAGE_END]` span attend bidirectionally. Here image tokens use the standard
+causal sparse pattern, so a token sees at most 128 of a span up to 384 tokens, and no later
+patches at all. The closest measured analogue (vLLM
+[#40106](https://github.com/vllm-project/vllm/issues/40106), Gemma-4) shows KL 0.03–0.09
+concentrated at image positions. Expect degradation on dense-intra-image work — OCR, charts,
+documents — and note it will still pass a smoke test.
+
+**2. `bias_vl` is loaded but not applied.** Image tokens currently route through the text
+gate bias. Because every image slot carries the same placeholder id, hash routing also sends
+them all to one expert — which is very likely the reason `bias_vl` exists. Correct handling
+needs modality threaded into the MoE gate.
+
+Neither affects text-only requests: with no image tokens the code path is identical to 0731.
+
+## Run it
+
+```bash
+# both nodes: extract vLLM's model.py from the image, patch, and stage
+docker run --rm -v /var/tmp:/out --entrypoint bash $IMAGE -lc \
+  'cp /opt/env/lib/python3.12/site-packages/vllm/models/deepseek_v4/nvidia/model.py /out/ds4v_model.py
+   cp /opt/env/lib/python3.12/site-packages/vllm/model_executor/models/registry.py /out/ds4v_registry.py'
+sudo chown $(id -u):$(id -g) /var/tmp/ds4v_model.py /var/tmp/ds4v_registry.py
+python3 port/patch_vision.py   /var/tmp/ds4v_model.py
+python3 port/patch_registry.py /var/tmp/ds4v_registry.py
+cp port/ds4v_vision.py port/ds4v_mm.py /var/tmp/
+
+# stale inspection cache MUST go after changing model interfaces
+sudo rm -rf ~/.cache/vllm-dspark/modelinfos
+
+# worker first, then head
+./ds4-vision-tp2.sh 1     # bluey  (holds weights, NFS-exports them)
+./ds4-vision-tp2.sh 0     # asusi  (head, serves :8888)
+```
+
+Everything from the base recipe is unchanged: `--kv-cache-dtype nvfp4_ds_mla`,
+`--block-size 256`, DSpark `num_speculative_tokens: 5`, `draft_sample_method: probabilistic`,
+patch 3, and the full NCCL/env block.
+
+## Prior art
+
+vLLM issue [#54561](https://github.com/vllm-project/vllm/issues/54561) and draft PR
+[#54566](https://github.com/vllm-project/vllm/pull/54566) both opened 2026-08-31 with a
+parallel implementation validated on 2x RTX PRO 6000. Their fixes for the hash-routing guard,
+OOV sentinels, and `bias_vl` are worth reading — this port reaches the same conclusions
+independently on several points. **What is new here is GB10 / DGX Spark**, where the
+[NVIDIA forum position that day](https://forums.developer.nvidia.com/t/deepseek-v4-flash-vision-exp-is-released-as-open-weights/381911)
+was that the native vLLM vision processor would not work with this model, and the previous
+answer for vision on Spark was a sidecar VLM rather than a port.

--- a/vision-exp/README.md
+++ b/vision-exp/README.md
@@ -121,13 +121,34 @@ KV pool is a **per-boot** figure, not a fixed property — this repo's own READM
 11% swing between two boots of an identical config, because available KV memory on GB10
 varies with what else has touched unified memory.
 
-### Speculative depth: use k=3, not k=5
+### Speculative depth: use k=3, not k=5 — measured
 
 This release changed `num_nextn_predict_layers` from **1 to 3**. Carrying the 0731 recipe's
-`num_speculative_tokens: 5` across measurably underperforms — at 1M/gmu 0.78 it gave
-accept ratio **0.542**, mean accepted length **3.71**, and **52.1 tok/s** on count-to-300.
+`num_speculative_tokens: 5` across wastes the tail of every draft:
+
+| count-to-300, temp 0 | k=5 | **k=3** |
+|---|---|---|
+| accept ratio | 0.542 | **0.830** |
+| mean accepted length | 3.71 / max 6 (62%) | **3.49 / max 4 (87%)** |
+| throughput | 52.1 tok/s | **54.6** (peak 55.1) |
+
 `MTP_NUM_TOKENS=3` is what the repo's validated profile already specifies, and it matches the
 checkpoint's predict-layer count.
+
+### Throughput is below the text-only build — known, not yet explained
+
+54.6 tok/s on count-to-300 sits under the ~70-80 the text-only 0731 recipe reaches.
+Decomposing: 54.6 / 3.49 accepted-per-step = **15.6 decode steps/sec**, versus ~20 needed
+for 70 tok/s at the same acceptance. Since the drafter is now running at 87% of its
+ceiling, **the gap is per-step cost, not speculation.** Two untested candidates:
+
+1. **Vision tax.** This build sets `requires_raw_input_tokens = True` so the runner slices
+   and passes raw token ids every forward step (the text-only build does not), and the ViT
+   plus aligner stay resident on both ranks.
+2. **Context ceiling.** 1.5M means larger DSA indexer buffers per step than the 350K used in
+   the older "as running" block.
+
+A single reload at 350K with everything else held constant separates the two.
 
 ### Correctness spot-checks (temperature 0)
 

--- a/vision-exp/README.md
+++ b/vision-exp/README.md
@@ -121,7 +121,10 @@ KV pool is a **per-boot** figure, not a fixed property — this repo's own READM
 11% swing between two boots of an identical config, because available KV memory on GB10
 varies with what else has touched unified memory.
 
-### Speculative depth: use k=3, not k=5 — measured
+### Speculative depth: k=5 (the k=3 finding below was measured without Patch 4)
+
+> **Correction (2026-09-02, after [issue #48](../../../issues/48) and [PR #44](../../../pull/44)):** the A/B below was run with a launcher that did **not** bind-mount the Patch 4 `spec-dspark.py` (DSpark shared-expert loader fix). Without it the draft's always-on shared expert loads uninitialised, acceptance collapses, and the 0.542 accept ratio at k=5 is that loader's signature, not a property of the vision drafter. The launcher in this branch now mounts Patch 4 and defaults to **k=5**, matching the main recipe. Measured **with** Patch 4 on a second 2× DGX Spark (BPAMLUX, #48, warm, temp 0, 500K ctx): k=5 count-to-300 **85.5 tok/s** (accept 0.974, 5.88 tok/step) vs k=3 64.4; code 49.9 vs 49.5 (neutral); prose 29.5 vs 32.1 (k=3 +9%). The numbers below are kept for the record as the unpatched measurement; our own re-measurement on this rig is pending.
+
 
 This release changed `num_nextn_predict_layers` from **1 to 3**. Carrying the 0731 recipe's
 `num_speculative_tokens: 5` across wastes the tail of every draft:
@@ -137,7 +140,7 @@ checkpoint's predict-layer count.
 
 ### Throughput is below the text-only build — known, not yet explained
 
-54.6 tok/s on count-to-300 sits under the ~70-80 the text-only 0731 recipe reaches.
+54.6 tok/s on count-to-300 (unpatched, see the correction above; with Patch 4 the same workload measured 85.5 tok/s in #48) sits under the ~70-80 the text-only 0731 recipe reaches.
 Decomposing: 54.6 / 3.49 accepted-per-step = **15.6 decode steps/sec**, versus ~20 needed
 for 70 tok/s at the same acceptance. Since the drafter is now running at 87% of its
 ceiling, **the gap is per-step cost, not speculation.** Two untested candidates:
@@ -201,7 +204,7 @@ sudo rm -rf ~/.cache/vllm-dspark/modelinfos
 
 Everything from the base recipe is unchanged: `--kv-cache-dtype nvfp4_ds_mla`,
 `--block-size 256`, `draft_sample_method: probabilistic`, patch 3, and the full NCCL/env
-block. Use the validated agent-serving profile — **1.5M context, gmu 0.85, seqs 12, k=3**.
+block. Use the validated agent-serving profile — **1.5M context, gmu 0.85, seqs 12, k=5** (k=5 with Patch 4 mounted; the earlier k=3 profile predates the Patch 4 fix).
 
 > **gmu 0.78 vs 0.85:** `DEFAULT-CONFIG.md` warns that 0.80 "boots and passes smoke tests,
 > then dies under traffic" (issue #8) because DSpark allocates buffers on the *first real

--- a/vision-exp/ds4-vision-tp2.sh
+++ b/vision-exp/ds4-vision-tp2.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# ds4-vision-tp2.sh <0|1>
+# DeepSeek-V4-Flash-Vision-Exp, TP2 across asusi (rank0/head) + bluey (rank1).
+# Config is byte-for-byte from tonyd2wild/DeepSeek-v4-Flash-0731-DSpark-1M-NVFP4-KV-2x-DGX-Spark
+# DEFAULT-CONFIG.md "Exact vLLM command (as running)", with only these adaptations:
+#   * model path  -> the locally downloaded Vision-Exp checkpoint
+#   * rank map    -> asusi 192.168.192.3 (head) / bluey 192.168.192.1 (worker)
+#   * NCCL_IB_HCA / SOCKET_IFNAME -> this fleet's actual devices (the repo ships placeholders)
+#   * single NIC  -> plane B (roceP2p1s0f0) is NOT on a common subnet between these two nodes
+#                    (asusi 169.254.61.52 link-local vs bluey 192.168.193.1), so MERGE_NICS
+#                    would try to bring up RC QPs across mismatched subnets. Plane A only.
+set -euo pipefail
+NODE_RANK="${1:?usage: ds4-vision-tp2.sh <0|1>}"
+
+IMAGE="vllm-dspark-runtime:mia-raf-pr1-nvfp4-probe-c-keys-concurrency-p2b"
+NAME="vllm_ds4_vision"
+MODEL_IN_CONTAINER="/models/DeepSeek-V4-Flash-Vision-Exp"
+MASTER_ADDR="192.168.192.3"     # asusi
+MASTER_PORT="25440"
+PORT="8888"
+
+case "$NODE_RANK" in
+  0) HOST_IP=192.168.192.3; HEADLESS=""           # asusi = head, reads model over NFS from bluey
+     MODELS_HOST="/mnt/bluey-models" ;;
+  1) HOST_IP=192.168.192.1; HEADLESS="--headless" # bluey = worker, model is local
+     MODELS_HOST="/var/tmp/models" ;;
+  *) echo "rank must be 0 or 1" >&2; exit 2 ;;
+esac
+
+test -d "$MODELS_HOST/DeepSeek-V4-Flash-Vision-Exp" || {
+  echo "MODEL MISSING at $MODELS_HOST/DeepSeek-V4-Flash-Vision-Exp" >&2; exit 3; }
+test -f /var/tmp/patch3-scheduler.py || { echo "patch3-scheduler.py MISSING at /var/tmp" >&2; exit 4; }
+
+mkdir -p "$HOME/.cache/vllm-dspark" "$HOME/.cache/huggingface"
+docker rm -f "$NAME" 2>/dev/null || true
+
+SPEC='{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}'
+REASON='{"reasoning_parser":"deepseek_v4","reasoning_start_str":"<think>","reasoning_end_str":"</think>"}'
+
+docker run -d --name "$NAME" --restart no \
+  --network host --ipc host --shm-size 64g \
+  --ulimit memlock=-1:-1 --ulimit stack=67108864 \
+  --gpus all --device /dev/infiniband:/dev/infiniband \
+  -v "$MODELS_HOST:/models:ro" \
+  -v "$HOME/.cache/huggingface:/cache/huggingface" \
+  -v "$HOME/.cache/vllm-dspark:/vllm-cache" \
+  -v /var/tmp/patch3-scheduler.py:/opt/env/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py:ro \
+  `# Vision-Exp port: DeepseekV4ForCausalLM has no vision tower/aligner, so the` \
+  `# stock class rejects the checkpoint with "no module or parameter named aligner".` \
+  `# ds4v_model.py = image's model.py + patch_vision.py; ds4v_vision.py = ported ViT+Aligner.` \
+  -v /var/tmp/ds4v_model.py:/opt/env/lib/python3.12/site-packages/vllm/models/deepseek_v4/nvidia/model.py:ro \
+  -v /var/tmp/ds4v_vision.py:/opt/env/lib/python3.12/site-packages/vllm/models/deepseek_v4/nvidia/ds4v_vision.py:ro \
+  -v /var/tmp/ds4v_mm.py:/opt/env/lib/python3.12/site-packages/vllm/models/deepseek_v4/nvidia/ds4v_mm.py:ro \
+  `# vLLM decides is_multimodal_model from a STATIC arch-name table, not from the` \
+  `# class. This registry adds a multimodal alias pointing at the same class;` \
+  `# --hf-overrides below selects it. Without this: "is not a multimodal model".` \
+  -v /var/tmp/ds4v_registry.py:/opt/env/lib/python3.12/site-packages/vllm/model_executor/models/registry.py:ro \
+  -e HF_HOME=/cache/huggingface -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 -e HF_HUB_DISABLE_XET=1 \
+  -e VLLM_CACHE_ROOT=/vllm-cache \
+  -e DG_JIT_CACHE_DIR=/vllm-cache/deepgemm-cache \
+  -e FLASHINFER_WORKSPACE_BASE=/vllm-cache/flashinfer \
+  -e TILELANG_CACHE_DIR=/vllm-cache/tilelang \
+  -e TORCHINDUCTOR_CACHE_DIR=/vllm-cache/torchinductor-cache \
+  -e TRITON_CACHE_DIR=/vllm-cache/triton-cache \
+  -e TORCH_EXTENSIONS_DIR=/vllm-cache/torch_extensions \
+  -e VLLM_ENGINE_READY_TIMEOUT_S=3600 \
+  -e DSPARK_SLOT_CLAMP=1 \
+  -e VLLM_HOST_IP="$HOST_IP" \
+  -e VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+  -e VLLM_TRITON_MLA_SPARSE=1 \
+  -e VLLM_SPARSE_INDEXER_MAX_LOGITS_MB=256 \
+  -e VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0 \
+  -e VLLM_SKIP_INIT_MEMORY_CHECK=1 \
+  -e VLLM_USE_FLASHINFER_SAMPLER=1 \
+  -e VLLM_USE_B12X_MOE=1 -e VLLM_USE_B12X_WO_PROJECTION=1 \
+  -e VLLM_B12X_W4A16_FORCE_BLOCKS_PER_SM=0 -e VLLM_B12X_W4A16_FORCE_BLOCKS_MAX_M=16 \
+  -e B12X_W4A16_TC_DECODE=0 \
+  -e VLLM_DSPARK_CONFIDENCE_THRESHOLD=0.0 -e VLLM_DSPARK_CONFIDENCE_SCHEDULER=off \
+  -e VLLM_DSPARK_LOCAL_ARGMAX=1 -e VLLM_DSPARK_REPLICATE_MARKOV_W1=1 \
+  -e VLLM_DSPARK_FUSED_MARKOV_ARGMAX=0 -e VLLM_DSPARK_GPU_REJECTED_CONTEXT_MASK=1 \
+  -e VLLM_DSPARK_REFERENCE_KV_QUANT_DEQUANT=0 -e VLLM_DSPARK_HARDWARE_SCHEDULER_EARLY_STOP=1 \
+  -e VLLM_DSV4_B12X_COMPRESSED_MLA=0 \
+  -e VLLM_DSV4_DSPARK_DEFER_TARGET_CAPTURE=0 -e VLLM_DSV4_DSPARK_DEFER_TARGET_CAPTURE_EXACT=0 \
+  -e TORCH_CUDA_ARCH_LIST=12.1a -e FLASHINFER_CUDA_ARCH_LIST=12.1a -e FLASHINFER_DISABLE_VERSION_CHECK=1 \
+  -e TILELANG_CLEANUP_TEMP_FILES=1 -e DG_JIT_USE_NVRTC=0 -e DG_JIT_NVCC_COMPILER=/opt/env/bin/nvcc \
+  -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+  -e NCCL_NET=IB -e NCCL_IB_DISABLE=0 \
+  -e NCCL_IB_HCA=rocep1s0f0 \
+  -e NCCL_SOCKET_IFNAME=enp1s0f0np0 -e GLOO_SOCKET_IFNAME=enp1s0f0np0 -e TP_SOCKET_IFNAME=enp1s0f0np0 \
+  -e NCCL_IB_GID_INDEX=3 -e NCCL_CROSS_NIC=0 -e NCCL_IB_MERGE_NICS=0 \
+  -e NCCL_CUMEM_ENABLE=0 -e NCCL_IGNORE_CPU_AFFINITY=1 -e NCCL_DEBUG=WARN -e NCCL_NVLS_ENABLE=0 \
+  "$IMAGE" \
+  -lc "
+    export PATH=\"/opt/env/bin:/opt/env/nvvm/bin:/opt/env/targets/sbsa-linux/nvvm/bin:\${PATH:-}\";
+    export CUDA_HOME=\"\${CUDA_HOME:-/opt/env/targets/sbsa-linux}\";
+    export CUDA_PATH=\"\${CUDA_PATH:-\${CUDA_HOME}}\";
+    export CUDAToolkit_ROOT=\"\${CUDAToolkit_ROOT:-\${CUDA_HOME}}\";
+    export LD_LIBRARY_PATH=\"/opt/env/lib:/opt/env/targets/sbsa-linux/lib:\${LD_LIBRARY_PATH:-}\";
+    exec /opt/env/bin/vllm serve $MODEL_IN_CONTAINER \
+      --hf-overrides '{\"architectures\":[\"DeepseekV4VForConditionalGeneration\"]}' \
+      --served-model-name deepseek-v4-flash-dspark \
+      --host 0.0.0.0 --port $PORT \
+      --trust-remote-code \
+      --tensor-parallel-size 2 --pipeline-parallel-size 1 \
+      --kv-cache-dtype nvfp4_ds_mla \
+      --block-size 256 \
+      --max-model-len 350000 \
+      --max-num-seqs 12 \
+      --max-num-batched-tokens 8192 \
+      --max-cudagraph-capture-size 12 \
+      --gpu-memory-utilization 0.80 \
+      --enable-prefix-caching \
+      --async-scheduling \
+      --enable-chunked-prefill \
+      --speculative-config '$SPEC' \
+      --tokenizer-mode deepseek_v4 \
+      --distributed-executor-backend mp \
+      --tool-call-parser deepseek_v4 --enable-auto-tool-choice \
+      --reasoning-parser deepseek_v4 \
+      --reasoning-config '$REASON' \
+      --default-chat-template-kwargs '{\"thinking\":false}' \
+      --generation-config vllm \
+      --enable-flashinfer-autotune \
+      --nnodes 2 --node-rank $NODE_RANK --master-addr $MASTER_ADDR --master-port $MASTER_PORT $HEADLESS
+  "
+
+echo "launched $NAME rank=$NODE_RANK host=$HOST_IP models=$MODELS_HOST"
+sleep 3
+docker ps --format '{{.Names}} {{.Status}}' | grep "$NAME" || { echo "$NAME exited immediately" >&2; exit 1; }

--- a/vision-exp/ds4-vision-tp2.sh
+++ b/vision-exp/ds4-vision-tp2.sh
@@ -30,11 +30,13 @@ esac
 test -d "$MODELS_HOST/DeepSeek-V4-Flash-Vision-Exp" || {
   echo "MODEL MISSING at $MODELS_HOST/DeepSeek-V4-Flash-Vision-Exp" >&2; exit 3; }
 test -f /var/tmp/patch3-scheduler.py || { echo "patch3-scheduler.py MISSING at /var/tmp" >&2; exit 4; }
+test -f /var/tmp/spec-dspark.py || { echo "spec-dspark.py (Patch 4, DSpark shared-expert loader fix) MISSING at /var/tmp — source: recipe/overlay/vllm/v1/spec_decode/dspark.py on main" >&2; exit 4; }
 
 mkdir -p "$HOME/.cache/vllm-dspark" "$HOME/.cache/huggingface"
 docker rm -f "$NAME" 2>/dev/null || true
 
-SPEC='{"method":"dspark","num_speculative_tokens":3,"draft_sample_method":"probabilistic"}'
+# k=5 matches the main default recipe. The earlier k=3 default came from an A/B run without the Patch 4 mount (issue #48).
+SPEC='{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}'
 REASON='{"reasoning_parser":"deepseek_v4","reasoning_start_str":"<think>","reasoning_end_str":"</think>"}'
 
 docker run -d --name "$NAME" --restart no \
@@ -45,6 +47,8 @@ docker run -d --name "$NAME" --restart no \
   -v "$HOME/.cache/huggingface:/cache/huggingface" \
   -v "$HOME/.cache/vllm-dspark:/vllm-cache" \
   -v /var/tmp/patch3-scheduler.py:/opt/env/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py:ro \
+  `# Patch 4: DSpark draft shared-expert loader fix. Without it the always-on shared expert loads uninitialised and the draft runs at ~half speed, silently (DSPARK-SHARED-EXPERT-FIX.md). Verify: scripts/check-patch4.sh` \
+  -v /var/tmp/spec-dspark.py:/opt/env/lib/python3.12/site-packages/vllm/v1/spec_decode/dspark.py:ro \
   `# Vision-Exp port: DeepseekV4ForCausalLM has no vision tower/aligner, so the` \
   `# stock class rejects the checkpoint with "no module or parameter named aligner".` \
   `# ds4v_model.py = image's model.py + patch_vision.py; ds4v_vision.py = ported ViT+Aligner.` \

--- a/vision-exp/ds4-vision-tp2.sh
+++ b/vision-exp/ds4-vision-tp2.sh
@@ -34,7 +34,7 @@ test -f /var/tmp/patch3-scheduler.py || { echo "patch3-scheduler.py MISSING at /
 mkdir -p "$HOME/.cache/vllm-dspark" "$HOME/.cache/huggingface"
 docker rm -f "$NAME" 2>/dev/null || true
 
-SPEC='{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}'
+SPEC='{"method":"dspark","num_speculative_tokens":3,"draft_sample_method":"probabilistic"}'
 REASON='{"reasoning_parser":"deepseek_v4","reasoning_start_str":"<think>","reasoning_end_str":"</think>"}'
 
 docker run -d --name "$NAME" --restart no \
@@ -104,11 +104,11 @@ docker run -d --name "$NAME" --restart no \
       --tensor-parallel-size 2 --pipeline-parallel-size 1 \
       --kv-cache-dtype nvfp4_ds_mla \
       --block-size 256 \
-      --max-model-len 350000 \
+      --max-model-len 1500000 \
       --max-num-seqs 12 \
       --max-num-batched-tokens 8192 \
       --max-cudagraph-capture-size 12 \
-      --gpu-memory-utilization 0.80 \
+      --gpu-memory-utilization 0.85 \
       --enable-prefix-caching \
       --async-scheduling \
       --enable-chunked-prefill \

--- a/vision-exp/port/ds4v_mm.py
+++ b/vision-exp/port/ds4v_mm.py
@@ -1,0 +1,341 @@
+"""Multimodal plumbing for DeepSeek-V4-Flash-Vision-Exp in vLLM.
+
+The checkpoint ships its own preprocessing (`inference/image_processor.py`) and
+no HuggingFace processor, so the pipeline here mirrors PixtralHF: override
+`_call_hf_processor` and do the work ourselves.
+
+Design note — why every block slot is a placeholder token:
+    The reference builds an image block containing four kinds of slot:
+    IMAGE (aligner output), plus IMAGE_START / IMAGE_PAD / IMAGE_NEWLINE /
+    IMAGE_END, which are *learned parameter vectors*, not vocabulary entries.
+    Rather than reproduce the reference's out-of-vocab `vocab_size + type`
+    sentinels, we emit `num_tokens` copies of the real in-vocab placeholder
+    token and return the ENTIRE assembled block from `embed_multimodal`. That
+    reproduces `merge_image_embeddings` exactly while keeping every token id in
+    vocabulary.
+
+Known fidelity gap (documented, not silently ignored):
+    The reference also computes `get_image_visible()` and threads per-token
+    left/right visibility into the sparse attention so tokens inside an image
+    span attend bidirectionally. That is NOT ported here — image tokens use the
+    standard causal sparse pattern. Expect some quality loss versus the
+    reference on image-heavy prompts.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from transformers import BatchFeature
+
+from vllm.config.multimodal import BaseDummyOptions
+from vllm.inputs import MultiModalDataDict
+from vllm.multimodal import MULTIMODAL_REGISTRY  # noqa: F401  (re-exported)
+from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargsItems
+from vllm.multimodal.parse import ImageProcessorItems, MultiModalDataItems
+from vllm.multimodal.processing import (
+    BaseDummyInputsBuilder,
+    BaseMultiModalProcessor,
+    BaseProcessingInfo,
+    PromptReplacement,
+    PromptUpdate,
+    PromptUpdateDetails,
+)
+
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+
+# Slot types, matching inference/image_processor.py
+IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(5)
+COMPRESS_PAD_TO = 4
+
+
+# --------------------------------------------------------------------------
+# Geometry + preprocessing: verbatim port of inference/image_processor.py
+# --------------------------------------------------------------------------
+def grid_tokens(best_height, best_width, patch_size, downsample_ratio):
+    n_llm_h = math.ceil((best_height // patch_size) / downsample_ratio)
+    n_llm_w = math.ceil((best_width // patch_size) / downsample_ratio)
+    num_tokens = n_llm_h * (n_llm_w + 1) + 2
+    if n_llm_h % 2 == 1:
+        num_tokens += n_llm_w + 1
+    num_tokens += (n_llm_h + 1) // 2 * (n_llm_w + 1) % 2 * 2
+    return n_llm_h, n_llm_w, num_tokens
+
+
+def solve_resize_ratio(height, width, patch_size, downsample_ratio, max_n_token):
+    r = height / width
+    max_w_float = math.sqrt((max_n_token - 2) / r + 0.25) - 0.5
+    max_h_float = max_w_float * r
+    if max_w_float < 1.0:
+        max_w = 1
+        max_h = (max_n_token - 2) // (max_w + 1)
+        if max_h % 2 == 1:
+            max_h -= 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    elif max_h_float < 2.0:
+        max_h = 2
+        max_w = ((max_n_token - 2) // max_h) - 1
+        assert max_w > 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    else:
+        max_w = math.floor(max_w_float)
+        max_h = math.floor(max_h_float)
+        if max_h % 2 == 1:
+            max_h -= 1
+        beta = min(max_w * patch_size * downsample_ratio / width,
+                   max_h * patch_size * downsample_ratio / height)
+        best_width = math.floor(width * beta / patch_size) * patch_size
+        best_height = math.floor(height * beta / patch_size) * patch_size
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio)
+    return n_llm_h, n_llm_w, best_height, best_width, num_tokens
+
+
+def safe_resize(height, width, best_height, best_width, patch_size,
+                downsample_ratio, max_n_token):
+    max_n_token -= COMPRESS_PAD_TO - 1
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio)
+    budget = max_n_token
+    while num_tokens > max_n_token:
+        n_llm_h, n_llm_w, best_height, best_width, num_tokens = solve_resize_ratio(
+            height, width, patch_size, downsample_ratio, budget)
+        budget -= 1
+    return n_llm_h, n_llm_w, best_height, best_width
+
+
+def image_to_patches(image, cfg):
+    """PIL.Image -> (patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w)."""
+    from PIL import ImageOps
+
+    p = int(cfg.vision_patch_size)
+    image = image.convert("RGB")
+    width, height = image.size
+    max_wh = getattr(cfg, "vision_max_wh_ratio", None)
+    if max_wh is not None and width > height * max_wh:
+        width = height * max_wh
+    min_px = getattr(cfg, "vision_min_pixels", 0)
+    if 0 < width * height < min_px:
+        ratio = (min_px / (width * height)) ** 0.5
+        width = int(width * ratio)
+        height = int(height * ratio)
+    best_width = math.ceil(width / p) * p
+    best_height = math.ceil(height / p) * p
+    n_llm_h, n_llm_w, best_height, best_width = safe_resize(
+        height, width, best_height, best_width, p,
+        int(cfg.vision_downsample_ratio), int(cfg.vision_max_n_token))
+    n_vit_h, n_vit_w = best_height // p, best_width // p
+    if max_wh is not None and image.width >= max_wh * image.height:
+        image = image.resize((best_width, best_height))
+    else:
+        image = ImageOps.pad(image, (best_width, best_height), color=(127, 127, 127))
+    x = torch.from_numpy(np.asarray(image, dtype=np.float32)).permute(2, 0, 1) / 255
+    x = ((x - 0.5) / 0.5).to(torch.bfloat16)
+    patches = x.reshape(3, n_vit_h, p, n_vit_w, p).permute(1, 3, 0, 2, 4)
+    patches = patches.reshape(n_vit_h * n_vit_w, 3, p, p)
+    return patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w
+
+
+def build_image_block(n_llm_h: int, n_llm_w: int, start_pos: int = 0):
+    """N-layout slot types (final order) + the aligner-row order for IMAGE slots."""
+    compress_pad = COMPRESS_PAD_TO - 1 - start_pos % COMPRESS_PAD_TO
+    pad_h = n_llm_h % 2
+    rows = n_llm_h + pad_h
+    row_len = n_llm_w + 1
+    pad_last = rows // 2 * row_len % 2 * 2
+    types = torch.tensor(
+        ([IMAGE] * n_llm_w + [IMAGE_NEW_LINE]) * n_llm_h + [IMAGE_PAD] * (row_len * pad_h),
+        dtype=torch.int64)
+    order = torch.arange(rows * row_len).view(rows // 2, 2, row_len).transpose(1, 2).reshape(-1)
+    image_idx = torch.full((rows * row_len,), -1, dtype=torch.int64)
+    image_idx.view(rows, row_len)[:n_llm_h, :n_llm_w] = torch.arange(
+        n_llm_h * n_llm_w).view(n_llm_h, n_llm_w)
+    perm = image_idx[order]
+    perm = perm[perm >= 0]
+    types = torch.cat([
+        torch.full((compress_pad,), IMAGE_PAD, dtype=torch.int64),
+        torch.tensor([IMAGE_START]),
+        types[order],
+        torch.full((pad_last,), IMAGE_PAD, dtype=torch.int64),
+        torch.tensor([IMAGE_END]),
+    ])
+    return types, perm
+
+
+# --------------------------------------------------------------------------
+# vLLM plumbing
+# --------------------------------------------------------------------------
+class DS4VProcessingInfo(BaseProcessingInfo):
+    def get_hf_config(self):
+        return self.ctx.model_config.hf_config
+
+    def get_supported_mm_limits(self) -> Mapping[str, int | None]:
+        # Registration is class-level, so text-only DeepSeek-V4-Flash-0731 also
+        # lands here. Report zero image support when the checkpoint has no
+        # vision tower, which keeps it a pure text model.
+        cfg = self.get_hf_config()
+        if int(getattr(cfg, "vision_n_layers", 0) or 0) <= 0:
+            return {"image": 0}
+        return {"image": None}
+
+    def get_num_image_tokens(self, *, image_width: int, image_height: int) -> int:
+        from PIL import Image
+
+        cfg = self.get_hf_config()
+        dummy = Image.new("RGB", (max(image_width, 1), max(image_height, 1)))
+        _, _, _, n_llm_h, n_llm_w = image_to_patches(dummy, cfg)
+        types, _ = build_image_block(n_llm_h, n_llm_w, 0)
+        return int(types.numel())
+
+    def get_max_image_tokens(self) -> int:
+        cfg = self.get_hf_config()
+        # vision_max_n_token is the budget the resize solver targets.
+        return int(cfg.vision_max_n_token) + COMPRESS_PAD_TO + 2
+
+
+class DS4VDummyInputsBuilder(BaseDummyInputsBuilder[DS4VProcessingInfo]):
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        return IMAGE_PLACEHOLDER * mm_counts.get("image", 0)
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, BaseDummyOptions] | None = None,
+    ) -> MultiModalDataDict:
+        num_images = mm_counts.get("image", 0)
+        cfg = self.info.get_hf_config()
+        # A square image near the token budget exercises the worst case.
+        side = int(cfg.vision_patch_size) * int(cfg.vision_downsample_ratio) * 6
+        overrides = (mm_options or {}).get("image")
+        return {
+            "image": self._get_dummy_images(
+                width=side, height=side, num_images=num_images, overrides=overrides
+            )
+        }
+
+
+class DS4VMultiModalProcessor(BaseMultiModalProcessor[DS4VProcessingInfo]):
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        cfg = self.info.get_hf_config()
+        tokenizer = self.info.get_tokenizer()
+        # vLLM hands the HF-processor convention: plural "images".
+        images = mm_data.get("images") or mm_data.get("image") or []
+        if not isinstance(images, list):
+            images = [images]
+
+        all_patches, grids, counts = [], [], []
+        for img in images:
+            patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w = image_to_patches(img, cfg)
+            all_patches.append(patches)
+            # types/perm are a pure function of the grid, so carry the grid only
+            # and rebuild them in embed_multimodal. Keeps every mm field either
+            # fixed-size-per-image or flat-with-sizes.
+            grids.append(torch.tensor([n_vit_h, n_vit_w, n_llm_h, n_llm_w],
+                                      dtype=torch.int64))
+            counts.append(patches.shape[0])
+
+        # Expand each placeholder into its full block HERE, not via
+        # _get_prompt_updates. vLLM sets is_update_applied=True for the
+        # text+mm path and then only *searches* the returned ids, so an
+        # unexpanded prompt yields "0 prompt placeholders". Expanding here is
+        # also what makes the position-dependent COMPRESS_PAD_TO alignment
+        # expressible at all — a replacement callable only receives item_idx.
+        placeholder_id = tokenizer.convert_tokens_to_ids(IMAGE_PLACEHOLDER)
+        raw_ids = tokenizer(prompt, add_special_tokens=False).input_ids
+        expanded: list[int] = []
+        img_i = 0
+        for tok in raw_ids:
+            if tok != placeholder_id or img_i >= len(grids):
+                expanded.append(tok)
+                continue
+            n_llm_h, n_llm_w = int(grids[img_i][2]), int(grids[img_i][3])
+            types, _ = build_image_block(n_llm_h, n_llm_w, 0)
+            expanded.extend([placeholder_id] * int(types.numel()))
+            img_i += 1
+        input_ids = expanded
+        out = {"input_ids": torch.tensor([input_ids], dtype=torch.int64)}
+        if all_patches:
+            # flat_from_sizes wants one concatenated tensor plus per-item sizes
+            out["image_patches"] = torch.cat(all_patches, dim=0)
+            out["num_patches"] = torch.tensor(counts, dtype=torch.int64)
+            out["image_grid"] = torch.stack(grids)
+        return BatchFeature(out)
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        # Patch counts differ per image, so `batched` cannot split them — it
+        # yields the wrong item count and blows up in _merge_mm_kwargs with
+        # "IndexError: list index out of range". Same shape as deepseek_vl2.py.
+        num_patches = hf_inputs.get("num_patches", torch.empty(0))
+        return dict(
+            image_patches=MultiModalFieldConfig.flat_from_sizes("image", num_patches),
+            num_patches=MultiModalFieldConfig.batched("image"),
+            image_grid=MultiModalFieldConfig.batched("image"),
+        )
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        out_mm_kwargs: MultiModalKwargsItems,
+    ) -> Sequence[PromptUpdate]:
+        cfg = self.info.get_hf_config()
+        tokenizer = self.info.get_tokenizer()
+        placeholder_id = tokenizer.convert_tokens_to_ids(IMAGE_PLACEHOLDER)
+
+        def get_replacement(item_idx: int):
+            images = mm_items.get_items("image", ImageProcessorItems)
+            size = images.get_image_size(item_idx)
+            n = self.info.get_num_image_tokens(
+                image_width=size.width, image_height=size.height)
+            # Every slot is the placeholder: embed_multimodal returns the whole
+            # block, learned START/PAD/NEWLINE/END vectors included.
+            return PromptUpdateDetails.select_token_id([placeholder_id] * n, placeholder_id)
+
+        return [
+            PromptReplacement(
+                modality="image",
+                target=[placeholder_id],
+                replacement=get_replacement,
+            )
+        ]
+
+
+def assemble_image_block(model, patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w):
+    """encode_image + slot assembly, mirroring reference merge_image_embeddings.
+
+    types/perm are rebuilt here from the grid rather than carried through the
+    multimodal kwargs — they are a pure function of (n_llm_h, n_llm_w).
+    """
+    types, perm = build_image_block(int(n_llm_h), int(n_llm_w), 0)
+    device = next(model.vision.parameters()).device
+    dtype = next(model.vision.parameters()).dtype
+    embeds = model.aligner(
+        model.vision(patches.to(device=device, dtype=dtype), int(n_vit_h), int(n_vit_w)),
+        int(n_vit_h), int(n_vit_w),
+    )[perm.to(device)]
+    params = torch.stack([
+        model.image_start, model.image_pad, model.image_pad,
+        model.image_newline, model.image_end,
+    ]).to(device=device, dtype=embeds.dtype)
+    types = types.to(device)
+    block = params[types]
+    block[types == IMAGE] = embeds
+    return block

--- a/vision-exp/port/ds4v_vision.py
+++ b/vision-exp/port/ds4v_vision.py
@@ -1,0 +1,158 @@
+"""DeepSeek-V4-Flash-Vision-Exp vision tower + aligner, ported for vLLM.
+
+Numerics are a verbatim port of the checkpoint's own reference implementation
+(`inference/vision.py` shipped inside DeepSeek-V4-Flash-Vision-Exp) so that
+outputs match the reference bit-for-bit modulo dtype.
+
+Deliberately NOT tensor-parallel sharded. The tower is ~410M params (~0.8 GiB
+bf16) and the reference runs it on a single device; replicating it on every TP
+rank costs less than the all-gather would and keeps the port faithful. Only the
+language model is sharded.
+"""
+from functools import lru_cache
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+@lru_cache(8)
+def get_vision_cos_sin(n_h: int, n_w: int, dim: int, theta: float, device: str = "cpu"):
+    """2D RoPE tables over the (n_h, n_w) patch grid. Cached: one image shape
+    recurs across every block and usually across requests."""
+    inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    hpos = torch.arange(n_h).unsqueeze(1).expand(n_h, n_w)
+    wpos = torch.arange(n_w).unsqueeze(0).expand(n_h, n_w)
+    freqs = torch.stack([hpos, wpos], dim=-1).reshape(-1, 2, 1).float() * inv_freq
+    freqs = freqs.flatten(1)
+    cos, sin = freqs.cos().unsqueeze(1), freqs.sin().unsqueeze(1)
+    if device != "cpu":
+        cos, sin = cos.to(device), sin.to(device)
+    return cos, sin
+
+
+def apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    dtype = x.dtype
+    x1, x2 = x.float().chunk(2, dim=-1)
+    return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1).to(dtype)
+
+
+class VisionRMSNorm(nn.Module):
+    """fp32 RMSNorm, matching the reference (vLLM's fused RMSNorm differs in
+    accumulation order; keep the reference's to preserve numerics)."""
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        dtype = x.dtype
+        x = x.float()
+        x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
+        return (self.weight * x).to(dtype)
+
+
+class PatchEmbed(nn.Module):
+    def __init__(self, patch_size: int, dim: int):
+        super().__init__()
+        self.proj = nn.Linear(3 * patch_size**2, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x.flatten(1))
+
+
+class VisionAttention(nn.Module):
+    def __init__(self, dim: int, n_heads: int):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = dim // n_heads
+        self.wqkv = nn.Linear(dim, 3 * dim)
+        self.wo = nn.Linear(dim, dim)
+
+    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        n = x.size(0)
+        q, k, v = (t.view(n, self.n_heads, self.head_dim) for t in self.wqkv(x).chunk(3, dim=-1))
+        q = apply_rotary(q, cos, sin)
+        k = apply_rotary(k, cos, sin)
+        # Full bidirectional attention over one image — no mask.
+        o = F.scaled_dot_product_attention(
+            q.transpose(0, 1), k.transpose(0, 1), v.transpose(0, 1)
+        )
+        return self.wo(o.transpose(0, 1).reshape(n, -1))
+
+
+class VisionMLP(nn.Module):
+    def __init__(self, dim: int, inter_dim: int):
+        super().__init__()
+        self.w1 = nn.Linear(dim, 2 * inter_dim, bias=False)
+        self.w2 = nn.Linear(inter_dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate, up = self.w1(x).chunk(2, dim=-1)
+        return self.w2(F.silu(gate) * up)
+
+
+class VisionBlock(nn.Module):
+    def __init__(self, dim: int, n_heads: int, inter_dim: int):
+        super().__init__()
+        self.norm1 = VisionRMSNorm(dim)
+        self.attn = VisionAttention(dim, n_heads)
+        self.norm2 = VisionRMSNorm(dim)
+        self.mlp = VisionMLP(dim, inter_dim)
+
+    def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), cos, sin)
+        return x + self.mlp(self.norm2(x))
+
+
+class ViT(nn.Module):
+    """DeepSeek ViT: full bidirectional attention over one image with 2D RoPE."""
+
+    def __init__(self, config):
+        super().__init__()
+        dim = config.vision_dim
+        n_heads = config.vision_n_heads
+        self.rope_dim = dim // n_heads // 2
+        self.rope_theta = config.vision_rope_theta
+        self.patch_embed = PatchEmbed(config.vision_patch_size, dim)
+        self.blocks = nn.ModuleList(
+            [VisionBlock(dim, n_heads, config.vision_inter_dim)
+             for _ in range(config.vision_n_layers)]
+        )
+        self.norm = VisionRMSNorm(dim)
+
+    def forward(self, patches: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        x = self.patch_embed(patches)
+        cos, sin = get_vision_cos_sin(
+            n_h, n_w, self.rope_dim, self.rope_theta, str(x.device)
+        )
+        for block in self.blocks:
+            x = block(x, cos, sin)
+        return self.norm(x)
+
+
+class Aligner(nn.Module):
+    """Pixel-shuffle downsample by `vision_downsample_ratio`, then 2-layer GELU MLP
+    into the language model's hidden size."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.downsample_ratio = config.vision_downsample_ratio
+        in_dim = config.vision_dim * self.downsample_ratio**2
+        self.w1 = nn.Linear(in_dim, config.hidden_size)
+        self.w2 = nn.Linear(config.hidden_size, config.hidden_size)
+
+    def forward(self, x: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        r = self.downsample_ratio
+        x = x.view(n_h, n_w, -1).permute(2, 0, 1)
+        x = F.pad(x, (0, -n_w % r, 0, -n_h % r))
+        x = F.unfold(x.unsqueeze(0), r, stride=r).squeeze(0).transpose(0, 1)
+        return self.w2(F.gelu(self.w1(x)))
+
+
+def build_vision_modules(config):
+    """Return (vision, aligner) or (None, None) when the checkpoint is text-only."""
+    if int(getattr(config, "vision_n_layers", 0) or 0) <= 0:
+        return None, None
+    return ViT(config), Aligner(config)

--- a/vision-exp/port/patch_registry.py
+++ b/vision-exp/port/patch_registry.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Register a multimodal architecture alias for DeepSeek-V4-Flash-Vision-Exp.
+
+vLLM answers `ModelConfig.is_multimodal_model` from a STATIC table keyed by
+architecture name — not by inspecting the class. `DeepseekV4ForCausalLM` lives in
+`_TEXT_GENERATION_MODELS`, so even with `SupportsMultiModal` in its MRO and a
+processor registered, the API server still refuses images with:
+
+    "<model> is not a multimodal model"
+
+The Vision-Exp checkpoint reports the SAME `architectures` string as text-only
+0731, so the name cannot simply be moved — that would break 0731. Instead we add
+an ALIAS in `_MULTIMODAL_MODELS` pointing at the same (patched) class, and select
+it for the vision checkpoint with:
+
+    --hf-overrides '{"architectures":["DeepseekV4VForConditionalGeneration"]}'
+
+Text-only 0731 keeps resolving through the untouched text-generation entry.
+This mirrors the approach taken upstream in vllm-project/vllm#54561 / #54566.
+
+Usage: patch_registry.py <path-to-registry.py>
+"""
+import sys
+
+ALIAS = "DeepseekV4VForConditionalGeneration"
+ANCHOR = "_MULTIMODAL_MODELS = {\n    # [Decoder-only]"
+BLOCK = (
+    "_MULTIMODAL_MODELS = {\n"
+    "    # [Decoder-only]\n"
+    "    # DeepSeek-V4-Flash-Vision-Exp. Alias onto the same class as the text-only\n"
+    "    # entry: the checkpoint reports architectures=['DeepseekV4ForCausalLM'],\n"
+    "    # so it is selected via --hf-overrides. See patch_registry.py docstring.\n"
+    f'    "{ALIAS}": ("vllm.models.deepseek_v4", "DeepseekV4ForCausalLM"),'
+)
+
+
+def main(path: str) -> int:
+    src = open(path).read()
+    if ALIAS in src:
+        print("already patched")
+        return 0
+    if src.count(ANCHOR) != 1:
+        print(f"ERROR: anchor found {src.count(ANCHOR)} times, expected 1", file=sys.stderr)
+        return 2
+    open(path, "w").write(src.replace(ANCHOR, BLOCK, 1))
+    print(f"patched {path}: registered {ALIAS} as multimodal")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1]))

--- a/vision-exp/port/patch_vision.py
+++ b/vision-exp/port/patch_vision.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Patch vLLM's vendored deepseek_v4 model.py to accept the Vision-Exp checkpoint.
+
+DeepSeek-V4-Flash-Vision-Exp adds a 32-block ViT, a 2-layer aligner, and four
+special embeddings on top of DeepSeek-V4-Flash-0731. vLLM's DeepseekV4ForCausalLM
+is the text-only class, so loading the vision checkpoint dies with:
+
+    ValueError: There is no module or parameter named 'aligner' in DeepseekV4ForCausalLM
+
+This makes three edits, all idempotent:
+  1. import the ported vision tower
+  2. build `vision` / `aligner` / `image_{start,end,newline,pad}` on DeepseekV4Model
+     when config.vision_n_layers > 0
+  3. teach the weights mapper the four new checkpoint prefixes
+
+Usage: patch_vision.py <path-to-model.py>
+"""
+import re
+import sys
+
+IMPORT_ANCHOR = "def _env_flag(*names: str) -> bool:"
+IMPORT_BLOCK = '''# --- DeepSeek-V4-Flash-Vision-Exp: vision tower + aligner -------------------
+try:
+    from vllm.models.deepseek_v4.nvidia.ds4v_vision import build_vision_modules
+except Exception:  # pragma: no cover - text-only checkpoints must still import
+    build_vision_modules = None
+
+
+def _ds4v_image_token_id(vllm_config, default: int = 129264) -> int:
+    """Resolve `<|deepseek_image|>` to its token id.
+
+    Looked up from the real tokenizer so this survives a vocab change; the
+    default is the id in the 2026-08-31 Vision-Exp release, used only if the
+    tokenizer cannot be loaded here.
+    """
+    try:
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(
+            vllm_config.model_config.tokenizer, trust_remote_code=True
+        )
+        tid = tok.convert_tokens_to_ids("<｜deepseek_image｜>")
+        if isinstance(tid, int) and tid >= 0:
+            return tid
+    except Exception:
+        pass
+    return default
+# ---------------------------------------------------------------------------
+
+
+'''
+
+INIT_ANCHOR = "        self.hc_head_op = HCHeadOp()"
+INIT_BLOCK = """
+        # --- Vision-Exp: tower + aligner + the four special embeddings ------
+        # Present only when the checkpoint carries them, so this file still
+        # loads DeepSeek-V4-Flash-0731 (text-only) unchanged.
+        self.vision = None
+        self.aligner = None
+        n_vision_layers = int(getattr(config, "vision_n_layers", 0) or 0)
+        if n_vision_layers > 0:
+            if build_vision_modules is None:
+                raise RuntimeError(
+                    "checkpoint declares vision_n_layers=%d but ds4v_vision "
+                    "could not be imported" % n_vision_layers
+                )
+            self.vision, self.aligner = build_vision_modules(config)
+            # Not sharded: the tower is ~410M params and the reference runs it
+            # on one device. Replicating beats an all-gather here.
+            for _name in ("image_start", "image_end", "image_newline", "image_pad"):
+                setattr(
+                    self,
+                    _name,
+                    nn.Parameter(
+                        torch.empty(config.hidden_size,
+                                    dtype=vllm_config.model_config.dtype),
+                        requires_grad=False,
+                    ),
+                )
+            self.max_image_tokens = int(getattr(config, "vision_max_n_token", 384))
+            # The DSpark proposer (and vLLM's VLM plumbing generally) expects the
+            # standard `image_token_index` field once a model reports as
+            # multimodal. DeepSeek's config doesn't carry one, so publish it here
+            # from the tokenizer's `<|deepseek_image|>` id.
+            if not hasattr(config, "image_token_index"):
+                config.image_token_index = _ds4v_image_token_id(vllm_config)
+        # --------------------------------------------------------------------
+"""
+
+# 4. keep the MLP stacked-params mapping off the vision/aligner weights.
+# The mapping rewrites any name containing ".w1"/".w3" into "gate_up_proj" for
+# fused MLPs. The ported ViT MLP and the aligner both legitimately use w1/w2,
+# so without this guard `aligner.w1.bias` becomes `aligner.gate_up_proj.bias`
+# and load_weights dies with a KeyError. Falling through to the generic
+# `else:` branch loads them with default_weight_loader, which is correct —
+# neither module is sharded.
+LOADER_ANCHOR = """            for param_name, weight_name, shard_id in stacked_params_mapping:
+                # Skip non-stacked layers and experts (experts handled below)."""
+LOADER_BLOCK = """            for param_name, weight_name, shard_id in stacked_params_mapping:
+                # Vision-Exp: the ViT MLP and the aligner use w1/w2 names that
+                # collide with the fused-MLP mapping below. Neither is sharded,
+                # so let them fall through to the generic loader.
+                if name.startswith(("vision.", "aligner.")):
+                    continue
+                # Skip non-stacked layers and experts (experts handled below)."""
+
+# 5. Vision-Exp's MoE gate carries a routing-correction bias on EVERY layer —
+# including the first `num_hash_layers` hash-MoE layers, which 0731 did not have
+# and which this file explicitly skips ("hash MoE doesn't use
+# e_score_correction_bias"). It also adds a SECOND bias, `bias_vl`, applied to
+# vision tokens, so experts are routed differently for image vs text tokens.
+# Both are new in this release and have no vLLM equivalent.
+GATE_ANCHOR = """        elif getattr(config, "topk_method", None) == "noaux_tc":
+            self.gate.e_score_correction_bias = nn.Parameter(
+                torch.empty(config.n_routed_experts, dtype=torch.float32),
+                requires_grad=False,
+            )"""
+GATE_BLOCK = """        elif getattr(config, "topk_method", None) == "noaux_tc":
+            self.gate.e_score_correction_bias = nn.Parameter(
+                torch.empty(config.n_routed_experts, dtype=torch.float32),
+                requires_grad=False,
+            )
+
+        # --- Vision-Exp gate biases ----------------------------------------
+        # Guarded on vision_n_layers so text-only DeepSeek-V4-Flash-0731 keeps
+        # exactly its previous behaviour (no bias on hash layers, no bias_vl).
+        self.gate.e_score_correction_bias_vl = None
+        if int(getattr(config, "vision_n_layers", 0) or 0) > 0:
+            if self.gate.e_score_correction_bias is None:
+                # hash-MoE layers now carry one too
+                self.gate.e_score_correction_bias = nn.Parameter(
+                    torch.empty(config.n_routed_experts, dtype=torch.float32),
+                    requires_grad=False,
+                )
+            self.gate.e_score_correction_bias_vl = nn.Parameter(
+                torch.empty(config.n_routed_experts, dtype=torch.float32),
+                requires_grad=False,
+            )
+        # --------------------------------------------------------------------"""
+
+MAPPER_ANCHOR = '            "mtp.": "model.mtp.",'
+MAPPER_BLOCK = '''            "mtp.": "model.mtp.",
+            # Vision-Exp additions
+            "vision.": "model.vision.",
+            "aligner.": "model.aligner.",
+            "image_start": "model.image_start",
+            "image_end": "model.image_end",
+            "image_newline": "model.image_newline",
+            "image_pad": "model.image_pad",'''
+
+
+# 7 + 8. Declare multimodal support and wire the image path.
+# vLLM's serving layer rejects images with "is not a multimodal model" unless the
+# class implements SupportsMultiModal AND a processor is registered for it.
+MM_CLASS_ANCHOR = """class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
+    model_cls = DeepseekV4Model"""
+MM_CLASS_BLOCK = '''@MULTIMODAL_REGISTRY.register_processor(
+    DS4VMultiModalProcessor,
+    info=DS4VProcessingInfo,
+    dummy_inputs=DS4VDummyInputsBuilder,
+)
+class DeepseekV4ForCausalLM(nn.Module, SupportsPP, SupportsMultiModal):
+    model_cls = DeepseekV4Model
+
+    # DeepSeek-V4's first `num_hash_layers` MoE layers route experts by TOKEN ID
+    # (gate.tid2eid), not by hidden state. vLLM's multimodal path normally hands
+    # the model inputs_embeds with input_ids=None, which makes hash routing
+    # raise "DeepSeek V4 hash MoE routing requires input_ids." This flag keeps
+    # the raw token ids alongside the embeddings.
+    requires_raw_input_tokens: bool = True
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return DS4V_IMAGE_PLACEHOLDER
+        return None
+
+    def get_language_model(self):
+        """Return self, not a sub-module.
+
+        Standard vLLM VLMs keep the vision tower as a sibling of a separate
+        `language_model`. DeepSeek-V4-Flash-Vision-Exp instead carries the ViT
+        and aligner INSIDE the decoder stack, so the language model and this
+        wrapper are the same object. Callers (notably the DSpark proposer, which
+        does `get_language_model().model` / `.lm_head` to share embeddings and
+        the LM head) need `self` for those lookups to resolve.
+        """
+        return self
+
+    def embed_multimodal(self, **kwargs: object):
+        """Run the ViT + aligner and return one assembled block per image.
+
+        The whole block is returned — aligner outputs at IMAGE slots and the
+        learned image_start / image_pad / image_newline / image_end vectors at
+        the others — because every slot was emitted as a placeholder token.
+        """
+        patches = kwargs.get("image_patches")
+        grids = kwargs.get("image_grid")
+        if patches is None or grids is None:
+            return []
+        if self.model.vision is None:
+            raise RuntimeError(
+                "image input received but this checkpoint has no vision tower"
+            )
+        # `flat_from_sizes` hands back ONE concatenated [sum(n_patches),3,p,p]
+        # tensor, not a per-image list. Iterating it directly walks individual
+        # patches and feeds the patch embedder a [3,196] row instead of an
+        # [N,588] block ("mat1 and mat2 shapes cannot be multiplied").
+        if isinstance(patches, torch.Tensor) and patches.dim() == 4:
+            counts = kwargs.get("num_patches")
+            if counts is not None:
+                sizes = [int(c) for c in torch.as_tensor(counts).flatten().tolist()]
+                if sum(sizes) == patches.shape[0]:
+                    patches = list(torch.split(patches, sizes, dim=0))
+            if isinstance(patches, torch.Tensor):
+                # single image
+                patches = [patches]
+        if isinstance(grids, torch.Tensor) and grids.dim() == 2:
+            grids = list(grids)
+        blocks = []
+        for p, g in zip(patches, grids):
+            g = g.flatten()
+            # grid = (n_vit_h, n_vit_w, n_llm_h, n_llm_w)
+            blocks.append(
+                ds4v_assemble_image_block(
+                    self.model, p, int(g[0]), int(g[1]), int(g[2]), int(g[3])
+                )
+            )
+        return blocks'''
+
+MM_IMPORT_ANCHOR = "# --- DeepSeek-V4-Flash-Vision-Exp: vision tower + aligner -------------------"
+MM_IMPORT_BLOCK = """# --- DeepSeek-V4-Flash-Vision-Exp: multimodal plumbing ----------------------
+try:
+    from vllm.multimodal import MULTIMODAL_REGISTRY
+    from vllm.model_executor.models.interfaces import SupportsMultiModal
+    from vllm.models.deepseek_v4.nvidia.ds4v_mm import (
+        IMAGE_PLACEHOLDER as DS4V_IMAGE_PLACEHOLDER,
+        DS4VDummyInputsBuilder,
+        DS4VMultiModalProcessor,
+        DS4VProcessingInfo,
+        assemble_image_block as ds4v_assemble_image_block,
+    )
+except Exception as _ds4v_mm_err:  # pragma: no cover
+    raise
+# ---------------------------------------------------------------------------
+
+# --- DeepSeek-V4-Flash-Vision-Exp: vision tower + aligner -------------------"""
+
+# 10. Make embed_input_ids multimodal-aware.
+# The existing one-arg version silently ignores multimodal embeddings, so images
+# would never be spliced in. It must also NOT route text embedding through
+# get_language_model() — that returns self here, which would recurse forever.
+EMBED_ANCHOR = """    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)"""
+EMBED_BLOCK = '''    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings=None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Embed tokens, splicing image-block embeddings at placeholder slots.
+
+        Text embedding goes straight to `self.model.embed_input_ids` rather than
+        `self.get_language_model()` — the latter returns `self` for this model,
+        which would recurse.
+        """
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.model.embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+        if is_multimodal is None:
+            raise ValueError(
+                "is_multimodal mask is required when multimodal embeddings are "
+                "provided"
+            )
+        from vllm.model_executor.models.utils import _merge_multimodal_embeddings
+
+        return _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )'''
+
+SUFFIX_ANCHOR = '            ".ffn.gate.bias": ".ffn.gate.e_score_correction_bias",'
+SUFFIX_BLOCK = '''            ".ffn.gate.bias": ".ffn.gate.e_score_correction_bias",
+            ".ffn.gate.bias_vl": ".ffn.gate.e_score_correction_bias_vl",'''
+
+
+def main(path: str) -> int:
+    src = open(path).read()
+
+    if "ds4v_vision" in src:
+        print("already patched; nothing to do")
+        return 0
+
+    for anchor, name in ((IMPORT_ANCHOR, "import"),
+                         (INIT_ANCHOR, "__init__"),
+                         (LOADER_ANCHOR, "load_weights"),
+                         (MAPPER_ANCHOR, "mapper"),
+                         (SUFFIX_ANCHOR, "suffix"),
+                         (GATE_ANCHOR, "gate"),
+                         # MM_IMPORT_ANCHOR is created by edit 1, so it cannot be
+                         # validated against the unpatched source.
+                         (MM_CLASS_ANCHOR, "mm_class"),
+                         (EMBED_ANCHOR, "embed_input_ids")):
+        if src.count(anchor) != 1:
+            print(f"ERROR: {name} anchor found {src.count(anchor)} times, expected 1",
+                  file=sys.stderr)
+            return 2
+
+    src = src.replace(IMPORT_ANCHOR, IMPORT_BLOCK + IMPORT_ANCHOR, 1)
+    src = src.replace(INIT_ANCHOR, INIT_ANCHOR + INIT_BLOCK, 1)
+    src = src.replace(LOADER_ANCHOR, LOADER_BLOCK, 1)
+    src = src.replace(MAPPER_ANCHOR, MAPPER_BLOCK, 1)
+    src = src.replace(SUFFIX_ANCHOR, SUFFIX_BLOCK, 1)
+    src = src.replace(GATE_ANCHOR, GATE_BLOCK, 1)
+    src = src.replace(MM_IMPORT_ANCHOR, MM_IMPORT_BLOCK, 1)
+    src = src.replace(MM_CLASS_ANCHOR, MM_CLASS_BLOCK, 1)
+    src = src.replace(EMBED_ANCHOR, EMBED_BLOCK, 1)
+
+    open(path, "w").write(src)
+    print(f"patched {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1]))


### PR DESCRIPTION
DeepSeek released [**DeepSeek-V4-Flash-Vision-Exp**](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp) today. This deploys it on 2× DGX Spark at TP2 **with working native image input** and DSpark speculative decoding intact.

```
"Based on the image, the two colors are red and blue.
 Red is on the left side. Blue is on the right side."
```

Not a sidecar and not a VLM proxy — the model's own 32-block ViT and aligner running inside vLLM.

## Why a port was needed

vLLM's `DeepseekV4ForCausalLM` is the **text-only** class. The vision checkpoint reports the *same* `architectures` string while carrying 316 extra tensors vLLM has nowhere to put, so it doesn't load at all:

```
ValueError: There is no module or parameter named 'aligner' in DeepseekV4ForCausalLM
```

DeepSeek shipped only a reference implementation — its own `inference/README.md` calls it "a readable reference implementation rather than a production serving engine." There was nothing to configure.

## What's actually new in this checkpoint

Diffing configs, the language model is identical to 0731 except:

| | 0731 | Vision-Exp |
|---|---|---|
| vision keys | — | 10 (32-block ViT, dim 1024, patch 14, 2D RoPE) |
| `num_nextn_predict_layers` | 1 | **3** |
| `rms_norm_eps` | 1e-6 | 1e-20 |
| `ffn.gate.*` | `weight`, `tid2eid` | + **`bias`**, **`bias_vl`** |

That last row is a **modality-specific MoE routing bias** — image tokens route to different experts than text tokens — present on all 43 layers including the 3 hash-routing layers 0731 left unbiased. Undocumented in any paper or model card.

## Twelve blockers

Full list with errors in [`vision-exp/README.md`](vision-exp/README.md). The three most likely to catch anyone else:

- **vLLM answers `is_multimodal_model` from a static architecture-name table**, never inspecting the class. `SupportsMultiModal` in the MRO does nothing on its own — needs a registry alias plus `--hf-overrides`.
- **That inspection is cached on disk** in `$VLLM_CACHE_ROOT/modelinfos/`, keyed by module+class. Both names resolve to the same class, so the alias silently reused the stale pre-patch "text-only" entry. Clear `modelinfos/` after changing model interfaces.
- **DeepSeek-V4's first `num_hash_layers` MoE layers route by token id**, but vLLM's multimodal path passes `inputs_embeds` with `input_ids=None` → `DeepSeek V4 hash MoE routing requires input_ids`. Fixed with `requires_raw_input_tokens = True`.

## Measured (2× GB10, TP2, temperature 0)

| | |
|---|---|
| Text, count-to-100 | **55.9 tok/s** median · 58.0 peak |
| DSpark acceptance | 0.628 · **4.14** mean accepted length (k=5, max 6) |
| Vision, 336×336 + 26-token answer | **1.03 s** end to end |

Correctness verified on two discriminating tests (different colors, different split axis, different image sizes) — both exactly right, and image-block token counts match the reference math.

## Not parity — two documented deviations

1. **Bidirectional attention within image spans is not implemented.** The reference widens the sparse-attention window so image tokens attend bidirectionally; here they use the causal sparse pattern. Closest measured analogue (vLLM #40106, Gemma-4) shows KL 0.03–0.09 concentrated at image positions. Expect degradation on OCR/chart/document work, and note it still passes smoke tests.
2. **`bias_vl` is loaded but not applied** — image tokens currently route through the text gate bias.

Neither affects text-only requests. Every patch is guarded on `vision_n_layers`, so **0731 is unchanged**.

## Prior art

vLLM [#54561](https://github.com/vllm-project/vllm/issues/54561) and draft PR [#54566](https://github.com/vllm-project/vllm/pull/54566) went up the same day with a parallel implementation on 2× RTX PRO 6000. What's new here is **GB10 / DGX Spark**, where the [NVIDIA forum position that day](https://forums.developer.nvidia.com/t/deepseek-v4-flash-vision-exp-is-released-as-open-weights/381911) was that the native vLLM vision processor would not work with this model, and the previous answer for vision on Spark was a sidecar VLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
