### PR TITLE
Add build-ds4v-files.sh so the vision recipe works from a clean clone (#46)

### DIFF
--- a/vision-exp/README.md
+++ b/vision-exp/README.md
@@ -45,6 +45,37 @@ applies to text tokens, `bias_vl` to image tokens — experts are chosen differe
 modality. It appears on **all 43 layers**, including the 3 hash-routing layers that 0731
 left without any bias at all. No paper or model card documents it.
 
+## Staging the four bind-mounted files
+
+`ds4-vision-tp2.sh` bind-mounts four files from `/var/tmp`. **Generate them with one
+command, on every node:**
+
+```bash
+git clone https://github.com/tonyd2wild/DeepSeek-v4-Flash-Vision-Exp-DSpark-1M-NVFP4-KV-2x-DGX-Spark
+cd DeepSeek-v4-Flash-Vision-Exp-DSpark-1M-NVFP4-KV-2x-DGX-Spark/vision-exp
+./build-ds4v-files.sh                      # or: ./build-ds4v-files.sh <image-tag> <dest>
+```
+
+Two of the four are shipped in this repo and copied verbatim (`ds4v_vision.py`,
+`ds4v_mm.py`). The other two are **derived from the image you are actually running**:
+
+| file | provenance |
+|---|---|
+| `ds4v_vision.py` | shipped — `vision-exp/port/ds4v_vision.py` |
+| `ds4v_mm.py` | shipped — `vision-exp/port/ds4v_mm.py` |
+| `ds4v_model.py` | *generated* — image's `deepseek_v4/nvidia/model.py` + `port/patch_vision.py` |
+| `ds4v_registry.py` | *generated* — image's `model_executor/models/registry.py` + `port/patch_registry.py` |
+
+**Why the last two are generated rather than checked in:** both are copies of vLLM files.
+A checked-in copy would pin you to one image build and drift silently the moment the image
+moves. Generating them means the port always applies to the image you run, and the
+patchers fail loudly (anchor count != 1) if the image changed underneath them.
+
+The script verifies its own output before installing — both files must parse, and
+`ds4v_model.py` must carry the vision import, the `bias_vl` gate and the loader guard,
+while `ds4v_registry.py` must carry the multimodal alias. A patcher that silently no-ops
+fails here instead of surfacing later as `is not a multimodal model`.
+
 ## The port
 
 | file | what it does |

--- a/vision-exp/build-ds4v-files.sh
+++ b/vision-exp/build-ds4v-files.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# build-ds4v-files.sh [IMAGE] [DEST]
+#
+# Produces the four files that ds4-vision-tp2.sh bind-mounts. Run it on EVERY node.
+#
+# Two of the four are shipped in this repo and are copied verbatim:
+#   vision-exp/port/ds4v_vision.py   ported ViT + Aligner
+#   vision-exp/port/ds4v_mm.py       multimodal processing / dummy inputs / processor
+#
+# The other two are DERIVED from whatever image you are running, by applying the
+# patchers in vision-exp/port/ to files extracted from that image:
+#   ds4v_model.py     = <image>:.../deepseek_v4/nvidia/model.py + patch_vision.py
+#   ds4v_registry.py  = <image>:.../model_executor/models/registry.py + patch_registry.py
+#
+# They are derived rather than shipped on purpose: both are copies of vLLM files, so a
+# checked-in copy would silently pin you to one image build and drift the moment the
+# image moves. Generating them here means the port always applies to the image you
+# actually run, and the patchers fail loudly (anchor count != 1) if the image changed
+# under them. See issue #46.
+set -euo pipefail
+
+IMAGE="${1:-${DSPARK_VLLM_IMAGE:-vllm-dspark-runtime:mia-raf-pr1-nvfp4-probe-c-keys-concurrency-p2b}}"
+DEST="${2:-/var/tmp}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PORT="$HERE/port"
+
+for f in patch_vision.py patch_registry.py ds4v_vision.py ds4v_mm.py; do
+  test -f "$PORT/$f" || { echo "MISSING $PORT/$f -- run this from a clone of the repo" >&2; exit 2; }
+done
+docker image inspect "$IMAGE" >/dev/null 2>&1 || {
+  echo "MISSING image $IMAGE -- pull or build it first, or pass the tag as \$1" >&2; exit 3; }
+
+mkdir -p "$DEST"
+echo "image: $IMAGE"
+echo "dest : $DEST"
+
+# 1. copy the two files this repo owns
+install -m 0644 "$PORT/ds4v_vision.py" "$DEST/ds4v_vision.py"
+install -m 0644 "$PORT/ds4v_mm.py"     "$DEST/ds4v_mm.py"
+echo "  ds4v_vision.py    copied from repo"
+echo "  ds4v_mm.py        copied from repo"
+
+# 2. extract the two vLLM files from the image we will actually run
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+# The DSpark image keeps its interpreter in /opt/env/bin, which is not on the default
+# PATH for a plain `bash -lc` -- without this you get "python3: command not found".
+docker run --rm -v "$TMP:/out" --entrypoint bash "$IMAGE" -lc '
+  set -e
+  export PATH="/opt/env/bin:$PATH"
+  V=$(python3 -c "import vllm,os;print(os.path.dirname(vllm.__file__))")
+  cp "$V/models/deepseek_v4/nvidia/model.py" /out/ds4v_model.py
+  cp "$V/model_executor/models/registry.py"  /out/ds4v_registry.py
+'
+# container writes as root; make them ours before patching
+if [ ! -w "$TMP/ds4v_model.py" ]; then sudo chown "$(id -u):$(id -g)" "$TMP"/ds4v_*.py; fi
+
+# 3. apply the ports
+python3 "$PORT/patch_vision.py"   "$TMP/ds4v_model.py"
+python3 "$PORT/patch_registry.py" "$TMP/ds4v_registry.py"
+
+# 4. verify before installing -- a patcher that no-ops leaves you debugging a silent
+#    "is not a multimodal model" instead of a clear failure here
+python3 - "$TMP/ds4v_model.py" "$TMP/ds4v_registry.py" <<'PY'
+import ast, sys
+model, registry = sys.argv[1], sys.argv[2]
+m = open(model).read(); r = open(registry).read()
+ast.parse(m); ast.parse(r)
+assert "ds4v_vision" in m, "model.py: vision import missing"
+assert "e_score_correction_bias_vl" in m, "model.py: bias_vl gate missing"
+assert 'startswith(("vision.", "aligner."))' in m, "model.py: loader guard missing"
+assert "DeepseekV4VForConditionalGeneration" in r, "registry.py: multimodal alias missing"
+print("  verified: both files parse and carry every port marker")
+PY
+
+install -m 0644 "$TMP/ds4v_model.py"    "$DEST/ds4v_model.py"
+install -m 0644 "$TMP/ds4v_registry.py" "$DEST/ds4v_registry.py"
+echo "  ds4v_model.py     generated from $IMAGE + patch_vision.py"
+echo "  ds4v_registry.py  generated from $IMAGE + patch_registry.py"
+
+echo
+echo "All four staged in $DEST:"
+ls -la "$DEST"/ds4v_*.py | sed 's/^/  /'
+echo
+echo "NOTE: vLLM caches model inspection on disk keyed by module+class. After changing"
+echo "      these files, clear it or the old 'text-only' verdict is reused (issue: the"
+echo "      alias resolves to the same class):"
+echo "        rm -rf \$VLLM_CACHE_ROOT/modelinfos/"


### PR DESCRIPTION
Fixes #46, which was my bug.

The recipe bind-mounts four `/var/tmp/ds4v_*.py` files and never said where they come from. @Capicua25x is right that a clean clone cannot stand this up, and @BPAMLUX is right that the generation path works — the gap was that nothing on `main` connected the two.

`vision-exp/build-ds4v-files.sh` does it in one command, on any node:

```bash
cd vision-exp && ./build-ds4v-files.sh          # or: ./build-ds4v-files.sh <image-tag> <dest>
```

| file | provenance |
|---|---|
| `ds4v_vision.py` | shipped — copied from `port/` |
| `ds4v_mm.py` | shipped — copied from `port/` |
| `ds4v_model.py` | **generated** — image's `model.py` + `patch_vision.py` |
| `ds4v_registry.py` | **generated** — image's `registry.py` + `patch_registry.py` |

**The last two stay generated on purpose.** Both are copies of vLLM files; checking them in would pin the recipe to one image build and drift silently the moment the image moves. Generating them means the port always applies to the image you actually run, and the patchers fail loudly (anchor count != 1) if the image changed underneath.

The script verifies before installing — both files must parse, `ds4v_model.py` must carry the vision import, the `bias_vl` gate and the loader guard, `ds4v_registry.py` must carry the multimodal alias. A patcher that silently no-ops now fails here instead of surfacing later as `is not a multimodal model`, which is a much worse place to find out.

**Tested end to end on a GB10 node** against the deployed image tag, which turned up two bugs in my own script: `DEST` was never created, and the image keeps `python3` in `/opt/env/bin` so a plain `bash -lc` can't find it. Both fixed; the run now produces all four files and passes its own verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)