### PR TITLE
Guard inference-time JIT with VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS (#8)

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -148,6 +148,8 @@ VLLM_DSV4_DSPARK_DEFER_TARGET_CAPTURE_EXACT=0
 # restart of this 155 GiB two-node load; the second startup dies with no useful
 # error. 3600 matches the sparkrun profile (PR #19).
 VLLM_ENGINE_READY_TIMEOUT_S=3600
+# Inference-time RPC deadline (default 300s is shorter than a cold mid-inference JIT -- see #8)
+VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
 VLLM_TRITON_MLA_SPARSE=1
 VLLM_SPARSE_INDEXER_MAX_LOGITS_MB=256

--- a/docker-compose.dspark.yml
+++ b/docker-compose.dspark.yml
@@ -79,6 +79,16 @@ services:
       # the second startup then dies with no useful error. 3600 matches the
       # sparkrun profile (PR #19) — this line is the compose-side mirror.
       VLLM_ENGINE_READY_TIMEOUT_S: "${VLLM_ENGINE_READY_TIMEOUT_S:-3600}"
+      # Inference-time RPC deadline. ENGINE_READY_TIMEOUT_S above covers BOOT only.
+      # This one guards each execute_model call, and the vLLM default is 300s -- which
+      # is shorter than a cold CuTeDSL/TileLang JIT triggered by an MoE/batch shape the
+      # warmup never covered. When that happens mid-inference the worker blocks, the
+      # deadline declares it dead, and the engine shuts down (issue #8; same anatomy
+      # root-caused in MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark#65).
+      # 1800 covers observed inference-time JIT with margin. Raising it trades slower
+      # detection of a genuinely hung worker -- for that, the tell is 96% GPU at ~18W
+      # (spin-wait, not compute), which is far faster to check than any timeout.
+      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
       # Long-context crash fix kill-switch (see docs/LONG_CONTEXT_CRASH_FIX.md).
       # 1 (default) = clamp stale DSpark draft-KV slot ids; 0 = detect+log only.
       DSPARK_SLOT_CLAMP: "${DSPARK_SLOT_CLAMP:-1}"

--- a/vision-exp/ds4-vision-tp2.sh
+++ b/vision-exp/ds4-vision-tp2.sh
@@ -68,6 +68,10 @@ docker run -d --name "$NAME" --restart no \
   -e TRITON_CACHE_DIR=/vllm-cache/triton-cache \
   -e TORCH_EXTENSIONS_DIR=/vllm-cache/torch_extensions \
   -e VLLM_ENGINE_READY_TIMEOUT_S=3600 \
+  `# Inference-time RPC deadline -- ENGINE_READY_TIMEOUT_S above covers boot only.` \
+  `# vLLM default is 300s, shorter than a cold JIT triggered mid-inference by an` \
+  `# MoE/batch shape warmup missed; the worker blocks and the engine is shut down (#8).` \
+  -e VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}" \
   -e DSPARK_SLOT_CLAMP=1 \
   -e VLLM_HOST_IP="$HOST_IP" \
   -e VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \


### PR DESCRIPTION
Closes the gap behind #8's engine deaths.

**The gap.** `VLLM_ENGINE_READY_TIMEOUT_S=3600` is set in the compose file and the vision launcher — but that covers **boot only**. The inference-time RPC deadline, `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS`, is set nowhere in this repo, so it runs at vLLM's **300 s** default. Verified on the live container: `VLLM_ENGINE_READY_TIMEOUT_S=3600` present, `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` absent.

**Why 300 s isn't enough.** A request hitting an MoE/batch shape the warmup never covered starts a cold CuTeDSL/TileLang JIT *during inference*. The worker blocks for minutes, the deadline fires, the worker is declared dead and the engine shuts down. That's the anatomy in #8, and [MiaAI-Lab#65](https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/issues/65) root-caused the identical shape on the 0.25.x lineage with the same fix.

It also fits the surrounding evidence: @Capicua25x measured **~36 minutes** of JIT retuning after an NCCL topology change (#38), and this repo's own arm-0 run of 138 scenarios that produced **zero engine events** also produced **zero `jit_monitor` warnings** — i.e. the clean runs are the ones where no JIT fired mid-inference.

**The change.** `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` defaults to 1800, overridable, in `docker-compose.dspark.yml`, `vision-exp/ds4-vision-tp2.sh` and `.env.dspark.example`.

**The trade, stated plainly:** a longer deadline means a genuinely hung worker takes longer to detect. I think that's clearly the right side of the trade here, because a real hang has a five-second tell that doesn't depend on any timeout — **96% GPU utilisation at ~18 W** is a spin-wait on a collective, not compute (@tsw2k, GLM TP4 #6). A GB10 doing real work draws far more; one legitimately mid-JIT sits near idle. So we're not trading away detection, just moving it off the timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)