### PR TITLE
Patch 6: keep the prefix cache alive on long conversations (protection cap + SWA page recycling)

### DIFF
--- a/.env.dspark.example
+++ b/.env.dspark.example
@@ -185,3 +185,9 @@ VLLM_SKIP_INIT_MEMORY_CHECK=1
 # nvfp4_ds_mla gives the 1M pool; fp8_ds_mla is the conservative choice
 # when 4-bit KV quality under long agentic context matters more than reach.
 #KV_CACHE_DTYPE=nvfp4_ds_mla
+
+# Patch 6 — prefix-cache retention on long conversations (docs/PATCH6-KV-CACHE-PREFIX-EVICTION.md)
+# Share of the KV pool the DSv4 prompt-block protection may pin, summed over KV groups (-1 = old unbounded behaviour).
+PROTECTED_FRACTION=0.30
+# Sliding-window/compressor groups reuse their own skipped pages instead of churning the global LRU (0 = old behaviour).
+SWA_RECYCLE=1

--- a/CURRENT.md
+++ b/CURRENT.md
@@ -31,9 +31,15 @@ Both launchers read `MODEL_DIR` (default `DeepSeek-V4-Flash-Vision-Exp`); the un
 
 **Preflight, on all four nodes:**
 
-- Patch 3 (`patch3-scheduler.py`), Patch 4 (`spec-dspark.py`) **and** the four vision port files
-  (`ds4v_model.py`, `ds4v_vision.py`, `ds4v_mm.py`, `ds4v_registry.py`) staged at `/var/tmp`.
-  The launcher checks all six and exits if any is missing.
+- Patch 3 (`patch3-scheduler.py`), Patch 4 (`spec-dspark.py`), Patch 6
+  (`patch6-single_type_kv_cache_manager.py`, source `recipe/overlay/vllm/v1/core/single_type_kv_cache_manager.py`)
+  **and** the four vision port files (`ds4v_model.py`, `ds4v_vision.py`, `ds4v_mm.py`, `ds4v_registry.py`)
+  staged at `/var/tmp`. The launcher checks all seven and exits if any is missing.
+- Patch 6 keeps the prefix cache alive on long conversations: both launchers pass
+  `VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION=${PROTECTED_FRACTION:-0.30}` and
+  `VLLM_SWA_RECYCLE_SKIPPED_BLOCKS=${SWA_RECYCLE:-1}`. Measured on TP2: a 354K-token prompt
+  re-sent after another 354K prefill hits 100% in 1.2 s (stock image: 0%, 235 s cold re-prefill);
+  logs in `docs/patch6-validation/`, analysis in `docs/PATCH6-KV-CACHE-PREFIX-EVICTION.md`.
 - Workers mount Bluey's weights export at `/mnt/bluey-models`.
 - **Drop page cache on all four nodes before launch.**
 
@@ -97,5 +103,7 @@ nothing a PR or issue links to changes path — `vision-exp/ds4-vision-tp2.sh` s
 The self-contained `sparkrun/` recipe serves under the id `deepseek-v4-flash-vision-exp`; the launchers here serve `deepseek-v4-flash-dspark`. Clients pointed at :8888 use the launcher's id.
 
 <!-- launcher hashes, maintained by tools/check-current.sh --write -->
-sha256 310e74b5a459f3cab876cd4d5edcbe67416ed74e408dfd965fd592a0bd0b1409  launchers/ds4-vision-tp2.sh
-sha256 3ace8ad8172c5a9c146e7dacc385b16d1e60049f65b7697527ec14eeead35ea4  launchers/ds4-vision-tp4.sh
+
+<!-- launcher hashes, maintained by tools/check-current.sh --write -->
+sha256 63a5f6c3ea32ecf764f76ac32ef7307dd637430301eab0ffc9bf0dbdd5d40531  launchers/ds4-vision-tp2.sh
+sha256 50b33b978f9c96ed318907519ff3f4e60abf15fb762c90345852e3c2cae1b266  launchers/ds4-vision-tp4.sh

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ first (`start-*.sh` does not copy bind-mounted files to the worker):
 #   *** REQUIRED. Without this mount the draft's always-on shared expert loads uninitialised
 #   *** and decode runs at ~half speed, failing SILENTLY (the drop is a logger.debug line).
 -v /var/tmp/spec-dspark.py:/opt/env/lib/python3.12/site-packages/vllm/v1/spec_decode/dspark.py:ro \
+# Patch 6 — prefix cache kept alive on long conversations (source: recipe/overlay/vllm/v1/core/single_type_kv_cache_manager.py)
+#   Without it every long prefill evicts all other cached prefixes and the DSv4 prompt-block
+#   protection pins pages forever (docs/PATCH6-KV-CACHE-PREFIX-EVICTION.md).
+-v /var/tmp/patch6-single_type_kv_cache_manager.py:/opt/env/lib/python3.12/site-packages/vllm/v1/core/single_type_kv_cache_manager.py:ro \
 # Vision-model files (native image support): ds4v_model.py / ds4v_vision.py / ds4v_mm.py / ds4v_registry.py
 #   staged the same way onto the image's DeepSeek-V4 model + registry module paths.
 -v /var/tmp/ds4v_model.py:.../ds4v_model.py:ro \

--- a/docs/PATCH6-KV-CACHE-PREFIX-EVICTION.md
+++ b/docs/PATCH6-KV-CACHE-PREFIX-EVICTION.md
@@ -1,0 +1,56 @@
+# Patch 6 — stop long prefills from evicting every other cached prefix (DSV4 hybrid KV)
+
+Target: `vllm/v1/core/single_type_kv_cache_manager.py` in the DSpark runtime
+(`vllm-dspark-runtime:mia-raf-pr1-nvfp4-probe-c-keys-concurrency-p2b`,
+vLLM `0.21.1rc1.dev339+g1967a5627bc3`). Unified diff: `patch6-single_type_kv_cache_manager.diff`
+(91 changed lines, single file). Deploy like the other patches: stage at `/var/tmp/` on both
+nodes and bind-mount read-only over the module path; launcher `ds4-vision-tp2-spark-recycle.sh`.
+
+## Root cause (two parts, both in this file)
+
+1. **Unbounded prompt-block protection.** `MLAAttentionManager.cache_blocks` (opted in for
+   `model_version == "deepseek_v4"`) and `SlidingWindowMLAManager.cache_blocks` call
+   `_protect_prompt_blocks`, which `touch()`es prompt blocks — an extra `ref_cnt` that survives
+   the request. The only cap, `2 * max_model_len / block_size`, is 8,192–524,288 pages per
+   group at `max_model_len=1M`, i.e. larger than the pool (12,621 pages). The protected set
+   therefore grows by ~30–60 pages on *every* request (+0.45–0.79 pp of the pool), never shrinks
+   while idle, and is released only FIFO under allocation pressure — evicting the oldest
+   conversation's prefix first.
+2. **Sliding-window churn through the shared LRU.** DSV4's compressor/indexer groups use pages of
+   a few tokens. `remove_skipped_blocks` frees each skipped page to the global free queue and the
+   next `allocate_new_blocks` pops fresh pages from the queue *head*. One 354K-token prefill
+   cycles the whole pool several times, evicting every other request's cached pages — with any
+   amount of free space. The protection in (1) was the fork's shield against (2).
+
+Observed effect for an agent: the first call of a user turn (which cannot hit at the previous
+prompt boundary once the prior round's reasoning is stripped) re-prefills ~400K tokens
+(235 s) instead of 1–4 s, and any large intervening request (e.g. a background review)
+destroys the conversation's prefix.
+
+## Fix
+
+- Cap the protected set to a fraction of the pool, shared across the KV groups
+  (`VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION`, default 0.30; managers count themselves).
+- Sliding-window groups keep pages they skip in a per-request recycle list (ref_cnt kept,
+  hash evicted) and reuse them for that request's next allocations; leftovers are freed at
+  `free()`. Shared or protected pages (`ref_cnt != 1`) are freed as before.
+  `VLLM_SWA_RECYCLE_SKIPPED_BLOCKS=0` disables it. Admission accounting is unchanged
+  (conservative: it ignores recyclable pages).
+
+## Validation (2× DGX Spark, TP=2, DeepSeek-V4-Flash-Vision-Exp, DSpark on)
+
+```
+                                        stock build          Patch 5 (cap only)   Patch 5+6
+354K FULL, resend                       100%  1.3 s          100%  1.3 s          100%  1.2 s
+354K ALT, then FULL again               0%    236 s          0%    229 s          100%  1.2 s
+ALT again                               0%    235 s          0%    230 s          100%  1.3 s
+THIRD tree, then FULL / ALT             —                    —                    100% / 100%
+FULL + 300-token decode, then resend    —                    —                    100% (6.8 s decode)
+idle usage after 12 small requests      +0.47 pp each        +0.46 pp each        +0.48 pp each (capped later)
+idle usage after 80 small requests      ~37% (extrapolated)  15.2%                —
+greedy output vs stock                  reference            identical            identical
+1200-token generation (thinking off)    —                    —                    coherent, 35.6 tok/s
+reasoning_effort=max                    —                    —                    reasoning + answer returned
+```
+Small requests still pin pages until the cap engages (by design of the fork's protection);
+with the cap the pool stabilises (15% after 80 requests here) instead of growing forever.

--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -199,3 +199,16 @@ unchanged.
   illegal-memory / IMA crash appears.
 - `draft_sample_method=probabilistic` is a valid tuning option but is **not**
   needed to fix this garble once the scheduler guard is in place.
+
+---
+
+## Patch 6 — prefix cache lost on long conversations (protection cap + SWA page recycling)
+
+Long-context agent sessions saw the first call of most turns re-prefill the whole prompt
+(235 s for ~400K tokens) although identical resends hit 100%. Two causes in
+`vllm/v1/core/single_type_kv_cache_manager.py`: the DSv4 prompt-block protection has an
+effectively infinite cap at 1M context (pins ~30–60 pages per request, forever), and the
+sliding-window/compressor groups churn the shared LRU during any long prefill, evicting
+every other cached prefix. See `docs/PATCH6-KV-CACHE-PREFIX-EVICTION.md` for the analysis,
+the fix and the validation table; file: `recipe/overlay/vllm/v1/core/single_type_kv_cache_manager.py`,
+diff: `patches/0006-kv-cache-prompt-protection-cap-and-swa-recycle.patch`.

--- a/launchers/ds4-vision-tp2.sh
+++ b/launchers/ds4-vision-tp2.sh
@@ -32,6 +32,7 @@ test -d "$MODELS_HOST/$MODEL_DIR" || {
   echo "MODEL MISSING at $MODELS_HOST/$MODEL_DIR" >&2; exit 3; }
 test -f /var/tmp/patch3-scheduler.py || { echo "patch3-scheduler.py MISSING at /var/tmp" >&2; exit 4; }
 test -f /var/tmp/spec-dspark.py || { echo "spec-dspark.py (Patch 4, DSpark shared-expert loader fix) MISSING at /var/tmp — source: recipe/overlay/vllm/v1/spec_decode/dspark.py on main" >&2; exit 4; }
+test -f /var/tmp/patch6-single_type_kv_cache_manager.py || { echo "patch6-single_type_kv_cache_manager.py (Patch 6, prefix-cache eviction fix) MISSING at /var/tmp — source: recipe/overlay/vllm/v1/core/single_type_kv_cache_manager.py on main" >&2; exit 4; }
 
 mkdir -p "$HOME/.cache/vllm-dspark" "$HOME/.cache/huggingface"
 docker rm -f "$NAME" 2>/dev/null || true
@@ -48,6 +49,10 @@ docker run -d --name "$NAME" --restart no \
   -v "$HOME/.cache/huggingface:/cache/huggingface" \
   -v "$HOME/.cache/vllm-dspark:/vllm-cache" \
   -v /var/tmp/patch3-scheduler.py:/opt/env/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py:ro \
+  `# Patch 6: cap prompt-block protection + recycle sliding-window pages in-request; without it long conversations lose their prefix cache (docs/PATCH6-KV-CACHE-PREFIX-EVICTION.md)` \
+  -v /var/tmp/patch6-single_type_kv_cache_manager.py:/opt/env/lib/python3.12/site-packages/vllm/v1/core/single_type_kv_cache_manager.py:ro \
+  -e VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION="${PROTECTED_FRACTION:-0.30}" \
+  -e VLLM_SWA_RECYCLE_SKIPPED_BLOCKS="${SWA_RECYCLE:-1}" \
   `# Patch 4: DSpark draft shared-expert loader fix. Without it the always-on shared expert loads uninitialised and the draft runs at ~half speed, silently (DSPARK-SHARED-EXPERT-FIX.md). Verify: scripts/check-patch4.sh` \
   -v /var/tmp/spec-dspark.py:/opt/env/lib/python3.12/site-packages/vllm/v1/spec_decode/dspark.py:ro \
   `# Vision-Exp port: DeepseekV4ForCausalLM has no vision tower/aligner, so the` \

--- a/launchers/ds4-vision-tp4.sh
+++ b/launchers/ds4-vision-tp4.sh
@@ -28,7 +28,7 @@ case "$NODE_RANK" in
 esac
 
 test -d "$MODELS_HOST/$MODEL_DIR" || { echo "MODEL MISSING at $MODELS_HOST/$MODEL_DIR" >&2; exit 3; }
-for f in patch3-scheduler.py spec-dspark.py ds4v_model.py ds4v_vision.py ds4v_mm.py ds4v_registry.py; do
+for f in patch3-scheduler.py spec-dspark.py patch6-single_type_kv_cache_manager.py ds4v_model.py ds4v_vision.py ds4v_mm.py ds4v_registry.py; do
   test -f "/var/tmp/$f" || { echo "MISSING /var/tmp/$f" >&2; exit 4; }
 done
 
@@ -46,6 +46,10 @@ docker run -d --name "$NAME" --restart no \
   -v "$HOME/.cache/huggingface:/cache/huggingface" \
   -v "$HOME/.cache/vllm-dspark:/vllm-cache" \
   -v /var/tmp/patch3-scheduler.py:/opt/env/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py:ro \
+  `# Patch 6: cap prompt-block protection + recycle sliding-window pages in-request (docs/PATCH6-KV-CACHE-PREFIX-EVICTION.md)` \
+  -v /var/tmp/patch6-single_type_kv_cache_manager.py:/opt/env/lib/python3.12/site-packages/vllm/v1/core/single_type_kv_cache_manager.py:ro \
+  -e VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION="${PROTECTED_FRACTION:-0.30}" \
+  -e VLLM_SWA_RECYCLE_SKIPPED_BLOCKS="${SWA_RECYCLE:-1}" \
   -v /var/tmp/spec-dspark.py:/opt/env/lib/python3.12/site-packages/vllm/v1/spec_decode/dspark.py:ro \
   -v /var/tmp/ds4v_model.py:/opt/env/lib/python3.12/site-packages/vllm/models/deepseek_v4/nvidia/model.py:ro \
   -v /var/tmp/ds4v_vision.py:/opt/env/lib/python3.12/site-packages/vllm/models/deepseek_v4/nvidia/ds4v_vision.py:ro \

--- a/patches/0006-kv-cache-prompt-protection-cap-and-swa-recycle.patch
+++ b/patches/0006-kv-cache-prompt-protection-cap-and-swa-recycle.patch
@@ -1,0 +1,150 @@
+--- a/vllm/v1/core/single_type_kv_cache_manager.py
++++ b/vllm/v1/core/single_type_kv_cache_manager.py
+@@ -1,10 +1,12 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ import itertools
++import os
+ from abc import ABC, abstractmethod
+ from collections import defaultdict, deque
+ from collections.abc import Sequence
+ 
++from vllm.logger import init_logger
+ from vllm.utils.math_utils import cdiv
+ from vllm.v1.core.block_pool import BlockPool
+ from vllm.v1.core.kv_cache_utils import (
+@@ -27,8 +29,29 @@
+ )
+ from vllm.v1.request import Request
+ 
++logger = init_logger(__name__)
++
++# Patch 5 (2026-09-06): bound the prompt-block protection set.
++# Upstream-of-this-fork behaviour caps protected prompt blocks at
++# 2 * max_model_len / block_size per KV group, which at max_model_len=1M and
++# block_size=256 (8,192 blocks) exceeds the whole pool (6,911 blocks): the
++# protected set then grows by ~30 blocks per request and is released only
++# FIFO under allocation pressure, evicting the live conversation's prefix.
++# VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION bounds the total protected share of
++# the pool across all KV groups (default 0.30). Set to 0 to disable protection.
++_PROTECTED_FRACTION_ENV = "VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION"
++# Patch 6 (2026-09-06): sliding-window / compressor groups recycle the pages they
++# skip (remove_skipped_blocks) back into the SAME request instead of freeing them
++# to the global LRU queue and popping fresh pages from its head. With few-token
++# pages, one long prefill otherwise cycles the whole pool several times and
++# evicts every other request's cached prefix (0% hit on the next turn of a long
++# conversation). VLLM_SWA_RECYCLE_SKIPPED_BLOCKS=0 disables it.
++_RECYCLE_ENV = "VLLM_SWA_RECYCLE_SKIPPED_BLOCKS"
++_RECYCLE_ENABLED = os.environ.get(_RECYCLE_ENV, "1").strip() not in ("0", "false", "False", "")
++
+ 
+ class SingleTypeKVCacheManager(ABC):
++    _num_managers: int = 0  # Patch 5: managers share one block pool
+     """
+     An abstract base class for a manager that handle the kv cache management
+     logic of one specific type of attention layer.
+@@ -86,6 +109,12 @@
+         self._null_block = block_pool.null_block
+         self._protected_prompt_block_ids: set[int] = set()
+         self._protected_prompt_block_queue: deque[int] = deque()
++        SingleTypeKVCacheManager._num_managers += 1
++        self._protected_cap_logged = False
++        # Patch 6: pages skipped by the sliding window, still owned by the
++        # request (ref_cnt kept), reused for its next allocations.
++        self._recycled_blocks: dict[str, list[KVCacheBlock]] = defaultdict(list)
++        self._recycle_logged = False
+ 
+     @classmethod
+     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
+@@ -268,7 +297,19 @@
+         if num_new_blocks <= 0:
+             return []
+         else:
+-            new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
++            reused: list[KVCacheBlock] = []
++            recycled = self._recycled_blocks.get(request_id)
++            if recycled:
++                take = min(num_new_blocks, len(recycled))
++                reused = recycled[-take:]
++                del recycled[-take:]
++                num_new_blocks -= take
++            new_blocks = (
++                self.block_pool.get_new_blocks(num_new_blocks)
++                if num_new_blocks > 0
++                else []
++            )
++            new_blocks = reused + new_blocks
+             req_blocks.extend(new_blocks)
+             if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+                 self.new_block_ids.extend(b.block_id for b in new_blocks)
+@@ -281,9 +322,27 @@
+         return ids
+ 
+     def _max_protected_prompt_blocks(self) -> int | None:
+-        if self.max_model_len is None:
+-            return None
+-        return 2 * cdiv(max(1, self.max_model_len), self.block_size)
++        legacy: int | None = None
++        if self.max_model_len is not None:
++            legacy = 2 * cdiv(max(1, self.max_model_len), self.block_size)
++        try:
++            fraction = float(os.environ.get(_PROTECTED_FRACTION_ENV, "0.30"))
++        except ValueError:
++            fraction = 0.30
++        if fraction < 0:
++            return legacy
++        num_managers = max(1, SingleTypeKVCacheManager._num_managers)
++        pool_cap = int(self.block_pool.num_gpu_blocks * fraction / num_managers)
++        cap = pool_cap if legacy is None else min(legacy, pool_cap)
++        if not self._protected_cap_logged:
++            self._protected_cap_logged = True
++            logger.info(
++                "Patch 5: protected prompt block cap for KV group %d = %d blocks "
++                "(pool %d blocks, %d managers, fraction %.2f, legacy cap %s)",
++                self.kv_cache_group_id, cap, self.block_pool.num_gpu_blocks,
++                num_managers, fraction, legacy,
++            )
++        return cap
+ 
+     def _protect_prompt_blocks(self, blocks: Sequence[KVCacheBlock]) -> None:
+         if not self.enable_caching:
+@@ -429,6 +488,9 @@
+ 
+         self.block_pool.free_blocks(ordered_blocks)
+         self.num_cached_block.pop(request_id, None)
++        leftover = self._recycled_blocks.pop(request_id, None)
++        if leftover:
++            self.block_pool.free_blocks(leftover)
+ 
+     @abstractmethod
+     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+@@ -536,7 +598,28 @@
+                 break
+             removed_blocks.append(blocks[i])
+             blocks[i] = self._null_block
+-        self.block_pool.free_blocks(removed_blocks)
++        if not _RECYCLE_ENABLED:
++            self.block_pool.free_blocks(removed_blocks)
++            return
++        to_free: list[KVCacheBlock] = []
++        recycled = self._recycled_blocks[request_id]
++        for blk in removed_blocks:
++            # Only pages held solely by this request can be reused in place;
++            # shared or protected pages keep their other references.
++            if blk.ref_cnt == 1 and not blk.is_null:
++                self.block_pool._maybe_evict_cached_block(blk)
++                recycled.append(blk)
++            else:
++                to_free.append(blk)
++        if to_free:
++            self.block_pool.free_blocks(to_free)
++        if not self._recycle_logged and recycled:
++            self._recycle_logged = True
++            logger.info(
++                "Patch 6: KV group %d recycling skipped pages in-request "
++                "(first request %s, %d pages)",
++                self.kv_cache_group_id, request_id, len(recycled),
++            )
+ 
+     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+         """

--- a/recipe/overlay/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/recipe/overlay/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1,0 +1,1504 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import itertools
+import os
+from abc import ABC, abstractmethod
+from collections import defaultdict, deque
+from collections.abc import Sequence
+
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    BlockHashList,
+    BlockHashWithGroupId,
+    KVCacheBlock,
+)
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    CrossAttentionSpec,
+    FullAttentionSpec,
+    HiddenStateCacheSpec,
+    KVCacheSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    SinkFullAttentionSpec,
+    SlidingWindowMLASpec,
+    SlidingWindowSpec,
+    TQFullAttentionSpec,
+)
+from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+# Patch 5 (2026-09-06): bound the prompt-block protection set.
+# Upstream-of-this-fork behaviour caps protected prompt blocks at
+# 2 * max_model_len / block_size per KV group, which at max_model_len=1M and
+# block_size=256 (8,192 blocks) exceeds the whole pool (6,911 blocks): the
+# protected set then grows by ~30 blocks per request and is released only
+# FIFO under allocation pressure, evicting the live conversation's prefix.
+# VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION bounds the total protected share of
+# the pool across all KV groups (default 0.30). Set to 0 to disable protection.
+_PROTECTED_FRACTION_ENV = "VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION"
+# Patch 6 (2026-09-06): sliding-window / compressor groups recycle the pages they
+# skip (remove_skipped_blocks) back into the SAME request instead of freeing them
+# to the global LRU queue and popping fresh pages from its head. With few-token
+# pages, one long prefill otherwise cycles the whole pool several times and
+# evicts every other request's cached prefix (0% hit on the next turn of a long
+# conversation). VLLM_SWA_RECYCLE_SKIPPED_BLOCKS=0 disables it.
+_RECYCLE_ENV = "VLLM_SWA_RECYCLE_SKIPPED_BLOCKS"
+_RECYCLE_ENABLED = os.environ.get(_RECYCLE_ENV, "1").strip() not in ("0", "false", "False", "")
+
+
+class SingleTypeKVCacheManager(ABC):
+    _num_managers: int = 0  # Patch 5: managers share one block pool
+    """
+    An abstract base class for a manager that handle the kv cache management
+    logic of one specific type of attention layer.
+    """
+
+    def __init__(
+        self,
+        kv_cache_spec: KVCacheSpec,
+        block_pool: BlockPool,
+        enable_caching: bool,
+        kv_cache_group_id: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+        max_admission_blocks_per_request: int | None = None,
+        max_model_len: int | None = None,
+    ) -> None:
+        """
+        Initializes the SingleTypeKVCacheManager.
+        Args:
+            kv_cache_spec: The kv_cache_spec for this manager.
+            block_pool: The block pool.
+            kv_cache_group_id: The id of the kv cache group of this manager.
+            max_admission_blocks_per_request: Recycling-aware per-request
+                block cap used by `get_num_blocks_to_allocate`. Only set for
+                spec types that recycle blocks across chunks (SWA,
+                chunked-local); `None` (the default) means no cap, which is
+                correct for full-attention-style specs that hold every
+                block until the request finishes.
+        """
+        self.block_size = kv_cache_spec.block_size
+        self.dcp_world_size = dcp_world_size
+        self.pcp_world_size = pcp_world_size
+        if dcp_world_size * pcp_world_size > 1:
+            self.block_size *= dcp_world_size * pcp_world_size
+        self.kv_cache_spec = kv_cache_spec
+        self.block_pool = block_pool
+        self.enable_caching = enable_caching
+        self._max_admission_blocks_per_request = max_admission_blocks_per_request
+        self.max_model_len = max_model_len
+        self.cache_alignment_tokens = self.block_size
+        self.new_block_ids: list[int] = []
+
+        # Mapping from request ID to blocks to track the blocks allocated
+        # for each request, so that we can free the blocks when the request
+        # is finished.
+        self.req_to_blocks: defaultdict[str, list[KVCacheBlock]] = defaultdict(list)
+
+        # {req_id: The number of cached blocks for this given request}
+        # This is used to track the number of cached blocks for each request.
+        # This is only used to track the RUNNING requests, we do not track the
+        # data for preempted ones.
+        self.num_cached_block: dict[str, int] = {}
+
+        self.kv_cache_group_id = kv_cache_group_id
+        self._null_block = block_pool.null_block
+        self._protected_prompt_block_ids: set[int] = set()
+        self._protected_prompt_block_queue: deque[int] = deque()
+        SingleTypeKVCacheManager._num_managers += 1
+        self._protected_cap_logged = False
+        # Patch 6: pages skipped by the sliding window, still owned by the
+        # request (ref_cnt kept), reused for its next allocations.
+        self._recycled_blocks: dict[str, list[KVCacheBlock]] = defaultdict(list)
+        self._recycle_logged = False
+
+    @classmethod
+    def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
+        return sum(blk.ref_cnt == 0 and not blk.is_null for blk in blocks)
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        """
+        Get the number of blocks needed to be allocated for the request.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix caching.
+            total_computed_tokens: Include both local and external computed
+                tokens.
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+            apply_admission_cap: If True, clamp by `num_required_blocks` by
+                `_max_admission_blocks_per_request`for recycling-aware specs
+                (SWA, chunked-local).
+
+        Returns:
+            The number of blocks to allocate.
+        """
+
+        num_required_blocks = cdiv(num_tokens, self.block_size)
+        if apply_admission_cap and self._max_admission_blocks_per_request is not None:
+            # Recycling-aware specs (SWA, chunked-local) cap the per-request
+            # reservation here so admission matches the startup pool sizer
+            # (`SlidingWindowSpec.max_admission_blocks_per_request` / its
+            # chunked-local counterpart). `remove_skipped_blocks` runs from
+            # `allocate_slots` before each chunk's `get_num_blocks_to_allocate`,
+            # so per-request peak real-held blocks <= this cap, which keeps
+            # `sum(reservations) <= pool` <=> `sum(peak_real_held) <= pool`.
+            # Drift between the two would re-introduce the deadlock from
+            # issue #39734 or, worse, mid-prefill OOM.
+            num_required_blocks = min(
+                num_required_blocks, self._max_admission_blocks_per_request
+            )
+        num_req_blocks = len(self.req_to_blocks.get(request_id, ()))
+
+        if request_id in self.num_cached_block:
+            # Fast-path: a running request won't have any new prefix-cache hits.
+            assert len(new_computed_blocks) == 0
+            # NOTE: With speculative decoding, request's blocks may be allocated
+            # for draft tokens which are later rejected. In this case,
+            # num_required_blocks may be smaller than num_req_blocks.
+            return max(num_required_blocks - num_req_blocks, 0)
+
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        num_local_computed_blocks = len(new_computed_blocks) + num_req_blocks
+        # Number of whole blocks that are skipped by the attention window.
+        # If nothing is skipped, this is 0.
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        # We need blocks for the non-skipped suffix. If there are still
+        # local-computed blocks inside the window, they contribute to the
+        # required capacity; otherwise, skipped blocks dominate.
+        num_new_blocks = max(
+            num_required_blocks - max(num_skipped_blocks, num_local_computed_blocks),
+            0,
+        )
+
+        # Among the `new_computed_blocks`, the first `num_skipped_blocks` worth
+        # of blocks are skipped; `num_req_blocks` of those may already be in
+        # `req_to_blocks`, so only skip the remainder from `new_computed_blocks`.
+        num_skipped_new_computed_blocks = max(0, num_skipped_blocks - num_req_blocks)
+
+        # If a computed block is an eviction candidate (in the free queue and
+        # ref_cnt == 0), it will be removed from the free queue when touched by
+        # the allocated request, so we must count it in the free-capacity check.
+        num_evictable_blocks = self._get_num_evictable_blocks(
+            new_computed_blocks[num_skipped_new_computed_blocks:]
+        )
+        return num_new_blocks + num_evictable_blocks
+
+    def allocate_new_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """
+        Add the new computed blocks to the request. This involves three steps:
+        1. Touch the computed blocks to make sure they won't be evicted.
+        1.5. (Optional) For sliding window, skip blocks are padded with null blocks.
+        2. Add the remaining computed blocks.
+        3. (Optional) For KV connectors, allocate new blocks for external computed
+            tokens (if any).
+
+        Args:
+            request_id: The request ID.
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix cache.
+            num_local_computed_tokens: The number of local computed tokens.
+            num_external_computed_tokens: The number of external computed tokens.
+        """
+
+        if request_id in self.num_cached_block:
+            # Fast-path: a running request won't have any new prefix-cache hits.
+            # It should not have any new computed blocks.
+            assert len(new_computed_blocks) == 0
+            return
+
+        # A new request.
+        req_blocks = self.req_to_blocks[request_id]
+        assert len(req_blocks) == 0
+        num_total_computed_tokens = (
+            num_local_computed_tokens + num_external_computed_tokens
+        )
+        num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        if num_skipped_blocks > 0:
+            # It is possible that all new computed blocks are skipped when
+            # num_skipped_blocks > len(new_computed_blocks).
+            new_computed_blocks = new_computed_blocks[num_skipped_blocks:]
+            # Some external computed tokens may be skipped too.
+            num_external_computed_tokens = min(
+                num_total_computed_tokens - num_skipped_tokens,
+                num_external_computed_tokens,
+            )
+
+        # Touch the computed blocks to make sure they won't be evicted.
+        if self.enable_caching:
+            self.block_pool.touch(new_computed_blocks)
+        else:
+            assert not any(new_computed_blocks), (
+                "Computed blocks should be empty when prefix caching is disabled"
+            )
+
+        # Skip blocks are padded with null blocks.
+        req_blocks.extend([self._null_block] * num_skipped_blocks)
+        # Add the remaining computed blocks.
+        req_blocks.extend(new_computed_blocks)
+        # All cached hits (including skipped nulls) are already cached; mark
+        # them so cache_blocks() will not try to re-cache blocks that already
+        # have a block_hash set.
+        self.num_cached_block[request_id] = len(req_blocks)
+
+        if num_external_computed_tokens > 0:
+            # Allocate new blocks for external computed tokens.
+            allocated_blocks = self.block_pool.get_new_blocks(
+                cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+            )
+            req_blocks.extend(allocated_blocks)
+            if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+                self.new_block_ids.extend(b.block_id for b in allocated_blocks)
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        """
+        Allocate new blocks for the request to give it at least `num_tokens`
+        token slots.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+        Returns:
+            The new allocated blocks.
+        """
+        req_blocks = self.req_to_blocks[request_id]
+        num_required_blocks = cdiv(num_tokens, self.block_size)
+        num_new_blocks = num_required_blocks - len(req_blocks)
+        if num_new_blocks <= 0:
+            return []
+        else:
+            reused: list[KVCacheBlock] = []
+            recycled = self._recycled_blocks.get(request_id)
+            if recycled:
+                take = min(num_new_blocks, len(recycled))
+                reused = recycled[-take:]
+                del recycled[-take:]
+                num_new_blocks -= take
+            new_blocks = (
+                self.block_pool.get_new_blocks(num_new_blocks)
+                if num_new_blocks > 0
+                else []
+            )
+            new_blocks = reused + new_blocks
+            req_blocks.extend(new_blocks)
+            if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+                self.new_block_ids.extend(b.block_id for b in new_blocks)
+            return new_blocks
+
+    def take_new_block_ids(self) -> list[int]:
+        """Drain and return block IDs allocated since the last call."""
+        ids = self.new_block_ids
+        self.new_block_ids = []
+        return ids
+
+    def _max_protected_prompt_blocks(self) -> int | None:
+        legacy: int | None = None
+        if self.max_model_len is not None:
+            legacy = 2 * cdiv(max(1, self.max_model_len), self.block_size)
+        try:
+            fraction = float(os.environ.get(_PROTECTED_FRACTION_ENV, "0.30"))
+        except ValueError:
+            fraction = 0.30
+        if fraction < 0:
+            return legacy
+        num_managers = max(1, SingleTypeKVCacheManager._num_managers)
+        pool_cap = int(self.block_pool.num_gpu_blocks * fraction / num_managers)
+        cap = pool_cap if legacy is None else min(legacy, pool_cap)
+        if not self._protected_cap_logged:
+            self._protected_cap_logged = True
+            logger.info(
+                "Patch 5: protected prompt block cap for KV group %d = %d blocks "
+                "(pool %d blocks, %d managers, fraction %.2f, legacy cap %s)",
+                self.kv_cache_group_id, cap, self.block_pool.num_gpu_blocks,
+                num_managers, fraction, legacy,
+            )
+        return cap
+
+    def _protect_prompt_blocks(self, blocks: Sequence[KVCacheBlock]) -> None:
+        if not self.enable_caching:
+            return
+
+        protected: list[KVCacheBlock] = []
+        for block in blocks:
+            if (
+                block.is_null
+                or block.block_hash is None
+                or block.block_id in self._protected_prompt_block_ids
+            ):
+                continue
+            protected.append(block)
+            self._protected_prompt_block_ids.add(block.block_id)
+            self._protected_prompt_block_queue.append(block.block_id)
+
+        if not protected:
+            return
+
+        # Keep an extra reference for prompt blocks that must survive after
+        # their request releases its normal runtime reference. Later request
+        # reuse increments/decrements the runtime reference as usual.
+        self.block_pool.touch(protected)
+        self._trim_protected_prompt_blocks()
+
+    def _trim_protected_prompt_blocks(self) -> None:
+        max_blocks = self._max_protected_prompt_blocks()
+        if max_blocks is None:
+            return
+
+        while len(self._protected_prompt_block_ids) > max_blocks:
+            if not self._release_one_protected_prompt_block():
+                return
+
+    def _release_one_protected_prompt_block(
+        self, block_ids_to_skip: set[int] | None = None
+    ) -> bool:
+        attempts = len(self._protected_prompt_block_queue)
+        while attempts:
+            block_id = self._protected_prompt_block_queue.popleft()
+            attempts -= 1
+            if block_id not in self._protected_prompt_block_ids:
+                continue
+            if block_ids_to_skip is not None and block_id in block_ids_to_skip:
+                self._protected_prompt_block_queue.append(block_id)
+                continue
+
+            self._protected_prompt_block_ids.remove(block_id)
+            block = self.block_pool.blocks[block_id]
+            if block.ref_cnt > 0:
+                self.block_pool.free_blocks([block])
+            return True
+        return False
+
+    def release_protected_prompt_blocks(
+        self,
+        target_free_blocks: int | None = None,
+        block_ids_to_skip: set[int] | None = None,
+    ) -> None:
+        while self._protected_prompt_block_ids:
+            if (
+                target_free_blocks is not None
+                and self.block_pool.get_num_free_blocks() >= target_free_blocks
+            ):
+                return
+            if not self._release_one_protected_prompt_block(block_ids_to_skip):
+                return
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        alignment_tokens: int | None = None,
+    ) -> None:
+        """
+        Cache the blocks for the request.
+
+        Args:
+            request: The request.
+            num_tokens: The total number of tokens that need to be cached
+                (including tokens that are already cached).
+            alignment_tokens: The cache-hit alignment (in tokens) used by the
+                coordinator's ``find_longest_cache_hit``. When greater than
+                this group's ``block_size``, managers whose hit logic only
+                returns a subset of blocks per alignment-aligned segment
+                (SWA) skip the rest since they can never participate in a
+                future cache hit.
+        """
+        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+        num_full_blocks = num_tokens // self.block_size
+
+        if num_cached_blocks >= num_full_blocks:
+            return
+
+        # Fast path: when the coordinator imposes no alignment constraint
+        if alignment_tokens is None or alignment_tokens <= self.block_size:
+            block_mask = None
+        else:
+            block_mask = self._cache_block_mask(
+                num_cached_blocks, num_full_blocks, alignment_tokens
+            )
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached_blocks,
+            num_full_blocks=num_full_blocks,
+            block_size=self.block_size,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_mask=block_mask,
+        )
+
+        self.num_cached_block[request.request_id] = num_full_blocks
+
+    def _cache_block_mask(
+        self,
+        num_cached_blocks: int,
+        num_full_blocks: int,
+        alignment_tokens: int,
+    ) -> list[bool] | None:
+        """Per-block mask for ``cache_full_blocks``. ``None`` means cache
+        every (non-null) block — the default for full attention.
+
+        Subclasses with sparse hit semantics (SWA) override this to skip
+        blocks that can never serve a hit at any alignment-aligned prefix
+        length.
+        """
+        return None
+
+    def free(self, request_id: str) -> None:
+        """
+        Free the blocks for the request.
+
+        Args:
+            request_id: The request ID.
+        """
+        # Default to [] in case a request is freed (aborted) before alloc.
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+
+        # Free blocks in reverse order so that the tail blocks are
+        # freed first.
+        ordered_blocks = reversed(req_blocks)
+
+        self.block_pool.free_blocks(ordered_blocks)
+        self.num_cached_block.pop(request_id, None)
+        leftover = self._recycled_blocks.pop(request_id, None)
+        if leftover:
+            self.block_pool.free_blocks(leftover)
+
+    @abstractmethod
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        Get the number of common prefix blocks for all requests with allocated
+        KV cache.
+
+        Args:
+            running_request_id: The request ID.
+
+        Returns:
+            The number of common prefix blocks for all requests with allocated
+            KV cache.
+        """
+
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        """
+        Get the longest cache hit prefix of the blocks that is not longer than
+        `max_length`. The prefix should be a common prefix hit for all the
+        kv cache groups in `kv_cache_group_ids`. If no cache hit is found,
+        return an empty list.
+        If eagle is enabled, drop the last matched block to force recompute the
+        last block to get the required hidden states for eagle drafting head.
+        Need to be customized for each attention type.
+
+        Args:
+            block_hashes: The block hashes of the request.
+            max_length: The maximum length of the cache hit prefix.
+            kv_cache_group_ids: The ids of the kv cache groups.
+            block_pool: The block pool.
+            kv_cache_spec: The kv cache spec.
+            use_eagle: Whether to use eagle.
+            alignment_tokens: The returned cache hit length (in tokens) should
+                be a multiple of this value (in tokens). By default, it should
+                be set to the block_size.
+            dcp_world_size: The world size of decode context parallelism.
+            pcp_world_size: The world size of prefill context parallelism.
+
+        Returns:
+            A list of cached blocks with skipped blocks replaced by null block
+            for each kv cache group in `kv_cache_group_ids`.
+            Return a list of length `len(kv_cache_group_ids)`, where the i-th
+            element is a list of cached blocks for the i-th kv cache group
+            in `kv_cache_group_ids`.
+            For example, sliding window manager should return a list like
+            ([NULL, NULL, KVCacheBlock(7), KVCacheBlock(8)]) for block size 4
+            and sliding window 8 and len(kv_cache_group_ids) = 1.
+        """
+
+        raise NotImplementedError
+
+    def remove_skipped_blocks(
+        self, request_id: str, total_computed_tokens: int
+    ) -> None:
+        """
+        Remove and free the blocks that are no longer needed for attention computation.
+        The removed blocks should be replaced by null_block.
+
+        This function depends on `get_num_skipped_tokens`, which need to be implemented
+        differently for each attention type.
+
+        Args:
+            request_id: The request ID.
+            total_computed_tokens: The total number of computed tokens, including
+                local computed tokens and external computed tokens.
+        """
+        # Remove the blocks that will be skipped during attention computation.
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        if num_skipped_tokens <= 0:
+            # This indicates that ALL tokens are inside attention window.
+            # Thus we do not need to free any blocks outside attention window.
+            # A typical case is full attention that we never free any token
+            # before the request is finished.
+            return
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        # `num_skipped_tokens` may include tokens that haven't been allocated yet
+        # (e.g., when the attention window moves into the external computed tokens
+        # range), so we must cap to the number of blocks that currently exist for
+        # this request.
+        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+        removed_blocks: list[KVCacheBlock] = []
+        # Because the block starts from index 0, the num_skipped_block-th block
+        # corresponds to index num_skipped_blocks - 1.
+        for i in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[i] == self._null_block:
+                # If the block is already a null block, the blocks before it
+                # should also have been set to null blocks by the previous calls
+                # to this function.
+                break
+            removed_blocks.append(blocks[i])
+            blocks[i] = self._null_block
+        if not _RECYCLE_ENABLED:
+            self.block_pool.free_blocks(removed_blocks)
+            return
+        to_free: list[KVCacheBlock] = []
+        recycled = self._recycled_blocks[request_id]
+        for blk in removed_blocks:
+            # Only pages held solely by this request can be reused in place;
+            # shared or protected pages keep their other references.
+            if blk.ref_cnt == 1 and not blk.is_null:
+                self.block_pool._maybe_evict_cached_block(blk)
+                recycled.append(blk)
+            else:
+                to_free.append(blk)
+        if to_free:
+            self.block_pool.free_blocks(to_free)
+        if not self._recycle_logged and recycled:
+            self._recycle_logged = True
+            logger.info(
+                "Patch 6: KV group %d recycling skipped pages in-request "
+                "(first request %s, %d pages)",
+                self.kv_cache_group_id, request_id, len(recycled),
+            )
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        # The default behavior is to not skip any tokens.
+        return 0
+
+    def new_step_starts(self) -> None:
+        # do nothing by default
+        return None
+
+
+class FullAttentionManager(SingleTypeKVCacheManager):
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(
+            kv_cache_spec, FullAttentionSpec | ChunkedLocalAttentionSpec
+        ), (
+            "FullAttentionManager can only be used for full attention "
+            "and chunked local attention groups"
+        )
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+        block_size = kv_cache_spec.block_size
+        if dcp_world_size * pcp_world_size > 1:
+            block_size *= dcp_world_size * pcp_world_size
+        max_num_blocks = max_length // block_size
+        for block_hash in itertools.islice(block_hashes, max_num_blocks):
+            # block_hashes is a chain of block hashes. If a block hash is not
+            # in the cached_block_hash_to_id, the following block hashes are
+            # not computed yet for sure.
+            if cached_block := block_pool.get_cached_block(
+                block_hash, kv_cache_group_ids
+            ):
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed.append(cached)
+            else:
+                break
+        if use_eagle and computed_blocks[0]:
+            # Need to drop the last matched block if eagle is enabled.
+            for computed in computed_blocks:
+                computed.pop()
+        while (
+            block_size != alignment_tokens  # Faster for common case.
+            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+        ):
+            for computed in computed_blocks:
+                computed.pop()
+        return computed_blocks
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        blocks = self.req_to_blocks[running_request_id]
+        num_common_blocks = 0
+        for block in blocks:
+            if block.ref_cnt == len(self.req_to_blocks):
+                num_common_blocks += 1
+            else:
+                break
+        return num_common_blocks
+
+
+class MLAAttentionManager(FullAttentionManager):
+    """KV cache manager for compressed / fp8 MLA cache layouts.
+
+    Used by any MLA spec whose hit semantics need prompt-block
+    protection across decode and unrelated cache churn. ``_should_
+    protect_prompt_blocks`` enumerates the triggering conditions.
+    """
+
+    def _should_protect_prompt_blocks(self) -> bool:
+        # Three independent triggers:
+        # 1. ``model_version == "deepseek_v4"``: DSv4 explicitly opts in.
+        # 2. ``cache_dtype_str == "fp8_ds_mla"``: fp8 DeepSeek-style
+        #    MLA cache; protection is needed for the same hybrid-align
+        #    reuse pattern.
+        # 3. ``compress_ratio > 1``: any compressed MLA cache (today
+        #    only DSv4 sets ``compress_ratio > 1``; V3.2 keeps it at 1).
+        return (
+            self.kv_cache_spec.model_version == "deepseek_v4"
+            or self.kv_cache_spec.cache_dtype_str == "fp8_ds_mla"
+            or self.kv_cache_spec.compress_ratio > 1
+        )
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        alignment_tokens: int | None = None,
+    ) -> None:
+        super().cache_blocks(request, num_tokens, alignment_tokens=alignment_tokens)
+        if not self._should_protect_prompt_blocks() or request.num_prompt_tokens <= 1:
+            return
+
+        max_cache_hit_length = request.num_prompt_tokens - 1
+        aligned_cache_hit_length = (
+            max_cache_hit_length
+            // self.cache_alignment_tokens
+            * self.cache_alignment_tokens
+        )
+        if aligned_cache_hit_length <= 0 or num_tokens < aligned_cache_hit_length:
+            return
+        num_hit_blocks = aligned_cache_hit_length // self.block_size
+        if num_hit_blocks == 0:
+            return
+
+        self._protect_prompt_blocks(
+            self.req_to_blocks[request.request_id][:num_hit_blocks]
+        )
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        blocks = self.req_to_blocks[running_request_id]
+        num_common_blocks = 0
+        expected_ref_cnt = len(self.req_to_blocks)
+        for block in blocks:
+            ref_cnt = block.ref_cnt
+            if block.block_id in self._protected_prompt_block_ids:
+                ref_cnt -= 1
+            if ref_cnt == expected_ref_cnt:
+                num_common_blocks += 1
+            else:
+                break
+        return num_common_blocks
+
+
+class SlidingWindowManager(SingleTypeKVCacheManager):
+    def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.sliding_window = kv_cache_spec.sliding_window
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(kv_cache_spec, SlidingWindowSpec), (
+            "SlidingWindowManager can only be used for sliding window groups"
+        )
+        assert dcp_world_size == 1, "DCP not support sliding window attn now."
+        assert pcp_world_size == 1, "PCP not support sliding window attn now."
+
+        # The number of contiguous blocks needed for prefix cache hit.
+        # -1 since the input token itself is also included in the window
+        sliding_window_contiguous_blocks = cdiv(
+            kv_cache_spec.sliding_window - 1, kv_cache_spec.block_size
+        )
+        if use_eagle:
+            # Need to drop the last matched block if eagle is enabled. For
+            # sliding window layer, we achieve this by increasing the number of
+            # contiguous blocks needed for prefix cache hit by one and dropping
+            # the last matched block.
+            sliding_window_contiguous_blocks += 1
+
+        # TODO: reduce i by sliding_window_contiguous_blocks when cache miss, to
+        # optimize the time complexity from O(max_num_blocks) to
+        # O(max_num_blocks / sliding_window_contiguous_blocks +
+        # sliding_window_contiguous_blocks),
+        # which is good for low cache hit rate scenarios.
+        max_num_blocks = max_length // kv_cache_spec.block_size
+        computed_blocks = tuple(
+            [block_pool.null_block] * max_num_blocks
+            for _ in range(len(kv_cache_group_ids))
+        )
+        block_size = kv_cache_spec.block_size
+        num_contiguous_blocks = 0
+        match_found = False
+        # Search from right to left and early stop when a match is found.
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(
+                block_hashes[i], kv_cache_group_ids
+            ):
+                # Skip prefix matching check if the block is not aligned with
+                # `alignment_tokens`.
+                if num_contiguous_blocks == 0 and block_size != alignment_tokens:
+                    post_pop_blocks = i if use_eagle else i + 1
+                    if (post_pop_blocks * block_size) % alignment_tokens != 0:
+                        continue
+                # Add the cached block to the computed blocks.
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed[i] = cached
+                num_contiguous_blocks += 1
+                if num_contiguous_blocks >= sliding_window_contiguous_blocks:
+                    # Trim the trailing blocks.
+                    # E.g., [NULL, NULL, 8, 3, NULL, 9] -> [NULL, NULL, 8, 3]
+                    # when sliding_window_contiguous_blocks=2.
+                    for computed in computed_blocks:
+                        del computed[i + num_contiguous_blocks :]
+                    match_found = True
+                    break
+            else:
+                num_contiguous_blocks = 0
+        if not match_found:
+            # The first `num_contiguous_blocks` is a cache hit even if
+            # `num_contiguous_blocks < sliding_window_contiguous_blocks`.
+            for computed in computed_blocks:
+                del computed[num_contiguous_blocks:]
+            while (
+                block_size != alignment_tokens  # Faster for common case.
+                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            ):
+                for computed in computed_blocks:
+                    computed.pop()
+        if use_eagle and computed_blocks[0]:
+            for computed in computed_blocks:
+                computed.pop()
+            # Re-align after eagle pop: the pop may break the alignment
+            # when block_size != alignment_tokens (hybrid models with
+            # different page sizes, e.g. Gemma4).
+            while (
+                block_size != alignment_tokens
+                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            ):
+                for computed in computed_blocks:
+                    computed.pop()
+        return computed_blocks
+
+    def _cache_block_mask(
+        self, num_cached_blocks: int, num_full_blocks: int, alignment_tokens: int
+    ) -> list[bool] | None:
+        assert alignment_tokens > self.block_size
+        # Eagle/MTP shifts alignment (post_pop_blocks = i, not i+1) and
+        # requires one extra contiguous block.  The resulting hit pattern
+        # can touch any position in the segment, so the mask must be
+        # disabled — otherwise prefix-cache hit rate drops to 0 %.
+        if getattr(self, "eagle_extra_cache_blocks", 0):
+            return None
+        per_segment = alignment_tokens // self.block_size
+        tail = cdiv(self.sliding_window - 1, self.block_size)
+        if tail >= per_segment:
+            return None
+        skip = per_segment - tail
+        return [
+            i % per_segment >= skip for i in range(num_cached_blocks, num_full_blocks)
+        ]
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        For sliding window, this corresponds to the tokens that are prior to
+        the current sliding window.
+
+        Example:
+        sliding_window=4, num_computed_tokens=7
+
+        Tokens:   [ 0  1  2  3  4  5  6  7 ]
+                  | ---- computed -----|
+                                         ^ next token to be computed
+                               |-----------| sliding window for next token
+                  |--skipped---|
+
+        The current window contains tokens 4~7. Tokens 0~3 will be skipped for
+        attention computation since they are outside the sliding window.
+        Thus, get_num_skipped_tokens(7) == 4.
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        return max(0, num_computed_tokens - self.sliding_window + 1)
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        NOTE(Chen): The prefix blocks are null blocks for sliding window layers.
+        So it's not correct to count ref_cnt like FullAttentionManager. Return
+        0 here for correctness. Need to support cascade attention + sliding
+        window in the future.
+        """
+        return 0
+
+
+class SlidingWindowMLAManager(SlidingWindowManager):
+    """KV cache manager for DeepSeek V4's sliding-window MLA cache.
+
+    During decode, the live sliding window can move past the prompt boundary.
+    The blocks around the hybrid-aligned prompt boundary are still the suffix
+    needed for a future prefix-cache hit of the same prompt.
+    """
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        alignment_tokens: int | None = None,
+    ) -> None:
+        super().cache_blocks(request, num_tokens, alignment_tokens=alignment_tokens)
+        if not self.enable_caching or request.num_prompt_tokens <= 1:
+            return
+
+        max_cache_hit_length = request.num_prompt_tokens - 1
+        aligned_cache_hit_length = (
+            max_cache_hit_length
+            // self.cache_alignment_tokens
+            * self.cache_alignment_tokens
+        )
+        if aligned_cache_hit_length <= 0 or num_tokens < aligned_cache_hit_length:
+            return
+
+        aligned_num_hit_blocks = aligned_cache_hit_length // self.block_size
+        last_full_prompt_block = max_cache_hit_length // self.block_size
+        contiguous_blocks = cdiv(self.sliding_window - 1, self.block_size)
+        first_protected_block = max(0, aligned_num_hit_blocks - contiguous_blocks)
+        last_protected_block = max(aligned_num_hit_blocks, last_full_prompt_block)
+        blocks = self.req_to_blocks[request.request_id]
+        protected_blocks = blocks[
+            first_protected_block : min(last_protected_block, len(blocks))
+        ]
+        self._protect_prompt_blocks(protected_blocks)
+
+
+class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
+    def __init__(self, kv_cache_spec: ChunkedLocalAttentionSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.attention_chunk_size = kv_cache_spec.attention_chunk_size
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        """
+        For chunked local attention, we need to find the longest cache hit
+        prefix of the blocks that is not longer than `max_length`. The prefix
+        should be a common prefix hit for all the kv cache groups in
+        `kv_cache_group_ids`. If no cache hit is found, return an empty list.
+        note we mark as computed if the whole block is outside of the local
+        window, and set the block as null. Examples:
+
+        1. Attention chunk size of 8, block size of 4, max length of 15
+        for next token at 15th (zero-indexed), 8th - 14th tokens are in
+        the window(needs lookup), 0th - 7th are not in the window,
+        so they are already marked as computed. We check the complete
+        block3 (8th - 11th tokens), Assume block 3 is hit, we will return
+        [null, null, block 3], otherwise, we return [null, null]
+
+        2. Attention chunk size of 8, block size of 4, max length of 16
+        for next token at 16th (zero-indexed), 0th - 15th tokens are not
+        in the window, so they are already marked as computed.
+        we return 4 blocks[null, null, null, null]
+
+        Args:
+            block_hashes: The block hashes of the request.
+            max_length: The maximum length of the cache hit prefix.
+            kv_cache_group_ids: The ids of the kv cache groups.
+            block_pool: The block pool.
+            kv_cache_spec: The kv cache spec.
+            use_eagle: Whether to use eagle.
+            dcp_world_size: The world size of decode context parallelism.
+            pcp_world_size: The world size of prefill context parallelism.
+            alignment_tokens: The returned cache hit length (in tokens) should
+                be a multiple of this value (in tokens).
+
+        Returns:
+            A list of cached blocks
+        """
+        assert isinstance(kv_cache_spec, ChunkedLocalAttentionSpec), (
+            "ChunkedLocalAttentionManager can only be used for "
+            "chunked local attention groups"
+        )
+        assert use_eagle is False, (
+            "Hybrid KV cache is not supported for " + "eagle + chunked local attention."
+        )
+        assert dcp_world_size == 1, "DCP not support chunked local attn now."
+        assert pcp_world_size == 1, "PCP not support chunked local attn now."
+        assert kv_cache_spec.block_size == alignment_tokens, (
+            "KV cache groups with different block sizes are not compatible with "
+            "chunked local attention now"
+        )
+        max_num_blocks = max_length // kv_cache_spec.block_size
+        if max_length > 0:
+            local_attention_start_idx = (
+                max_length
+                // kv_cache_spec.attention_chunk_size
+                * kv_cache_spec.attention_chunk_size
+            )
+        else:
+            local_attention_start_idx = 0
+        # we marked blocks out of window as computed
+        # with null blocks, and blocks inside window based on cache lookup
+        # result [null] [null] ... [null] [hit block 1 (1st block contain
+        # last window)] [hit block 2] ... [hit block x]
+        local_attention_start_block_idx = (
+            local_attention_start_idx // kv_cache_spec.block_size
+        )
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [block_pool.null_block] * local_attention_start_block_idx
+            for _ in range(len(kv_cache_group_ids))
+        )
+        for i in range(local_attention_start_block_idx, max_num_blocks):
+            block_hash = block_hashes[i]
+            if cached_block := block_pool.get_cached_block(
+                block_hash, kv_cache_group_ids
+            ):
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed.append(cached)
+            else:
+                break
+        return computed_blocks
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        For chunked local attention, this corresponds to the tokens that are on
+        the left side of the current chunk.
+
+        Example 1:
+        chunk size = 8, num_computed_tokens = 13
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 | ----- computed ---------------|
+                                                  ^^ next token to be computed
+                                   |----------------| <-- attention window for
+                                                          next token
+                 |--- skipped -----|
+        Output: get_num_skipped_tokens(13) == 8
+
+        Example 2:
+        chunk size = 8, num_computed_tokens = 8
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 | --- computed ---|
+                                     ^ next token to be computed
+                                   |--| <-- attention window for next token
+                 | --- skipped ----|
+        Output: get_num_skipped_tokens(8) == 8
+
+        Example 3:
+        chunk size = 8, num_computed_tokens = 7
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 |---computed---|
+                                 ^ next token to be computed
+                 |-----------------| <-- attention window for next token
+                 no token should be skipped.
+        Output: get_num_skipped_tokens(7) == 0
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        num_skipped_tokens = (
+            num_computed_tokens // self.attention_chunk_size
+        ) * self.attention_chunk_size
+        return num_skipped_tokens
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        cascade attention is not supported by chunked local attention.
+        """
+        return 0
+
+
+class MambaManager(SingleTypeKVCacheManager):
+    def __init__(
+        self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
+    ) -> None:
+        super().__init__(kv_cache_spec, block_pool, **kwargs)
+        self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
+        self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
+        self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
+        if self.mamba_cache_mode == "align":
+            # Mapping from request ID to the index of the block
+            # allocated in the previous step
+            self.last_state_block_idx: dict[str, int] = {}
+            # The set of the requests that have been allocated blocks
+            self._allocated_block_reqs: set[str] = set()
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(kv_cache_spec, MambaSpec), (
+            "MambaManager can only be used for mamba groups"
+        )
+        assert dcp_world_size == 1, "DCP not support mamba now."
+        assert pcp_world_size == 1, "PCP not support mamba now."
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+
+        block_size = kv_cache_spec.block_size
+        max_num_blocks = max_length // block_size
+        # Search from right to left and early stop when a match is found.
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(
+                block_hashes[i], kv_cache_group_ids
+            ):
+                # When enable Mamba prefix caching, `block_size` will be aligned
+                # across full attention layers and Mamba layers to ensure the
+                # prefix hit length aligned at block
+                if (
+                    block_size != alignment_tokens  # Faster for common case.
+                    and (i + 1) * block_size % alignment_tokens != 0
+                ):
+                    continue
+                for computed, cached in zip(computed_blocks, cached_block):
+                    # the hit length logic later assumes:
+                    #  hit_length = len(hit_blocks_other_attn[0])
+                    #               * self.other_block_size
+                    # so we insert dummy blocks at the beginning:
+                    computed.extend([block_pool.null_block] * i)
+                    computed.append(cached)
+                break  # we just need the last match - early stopping
+
+        return computed_blocks
+
+    def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+
+        # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
+        # draft tokens from the previous step that may or may not be rejected later.
+        # This can make us think we are further ahead in the sequence than we actually
+        # are, so let's assume that all tokens are rejected so we don't free blocks
+        # that we might actually need.
+        num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
+
+        super().remove_skipped_blocks(request_id, num_computed_tokens)
+        if self.mamba_cache_mode == "align":
+            # `last_state_block_idx` refers to the block index allocated two steps ago.
+            # The block allocated in the previous step is used to copy Mamba states
+            # into the block allocated in the current step; the earlier block is
+            # no longer needed and should be freed here.
+            last_state_block_idx = self.last_state_block_idx.get(request_id)
+            # Blocks allocated during prefill may be non-contiguous. Use
+            # `last_state_block_idx` to free the appropriate block and replace it
+            # with a null block.
+            if (
+                last_state_block_idx is not None
+                and last_state_block_idx
+                < cdiv(num_computed_tokens, self.block_size) - 1
+            ):
+                blocks = self.req_to_blocks[request_id]
+                if blocks[last_state_block_idx] != self._null_block:
+                    self.block_pool.free_blocks([blocks[last_state_block_idx]])
+                    blocks[last_state_block_idx] = self._null_block
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        cascade attention is not supported by mamba
+        """
+        return 0
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if (
+            len(new_computed_blocks) > 0
+            and new_computed_blocks[-1].block_hash in self.cached_blocks_this_step
+        ):
+            # Mamba can't rely on blocks generated by other requests in the current step
+            # To put it in the next step, we return num_gpu_blocks + 1 so
+            # that kv_cache_manager will think there is no enough blocks to allocate now
+            # and don't schedule it in the current step.
+            return self.block_pool.num_gpu_blocks + 1
+        if self.mamba_cache_mode != "align":
+            # Allocate extra `num_speculative_blocks` blocks for
+            # speculative decoding (MTP/EAGLE) with linear attention.
+            if self.num_speculative_blocks > 0:
+                num_tokens += (
+                    self.kv_cache_spec.block_size * self.num_speculative_blocks
+                )
+            return super().get_num_blocks_to_allocate(
+                request_id,
+                num_tokens,
+                new_computed_blocks,
+                total_computed_tokens,
+                num_tokens_main_model,
+                apply_admission_cap=apply_admission_cap,
+            )
+        else:
+            # We don't allocate blocks for lookahead tokens in align mode, because if
+            # x * block_size tokens are scheduled, num_tokens is
+            # x * block_size + num_lookahead_tokens and breaks the alignment.
+            # We can ignore lookahead tokens because current draft models don't have
+            # mamba layers.
+            num_tokens = num_tokens_main_model
+
+            # NOTE(tdouble): this is an over-estimate of how many blocks we need because
+            # num_tokens can include draft tokens that will later be rejected.
+            num_required_blocks = (
+                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
+            )
+            num_new_blocks = (
+                num_required_blocks
+                - len(new_computed_blocks)
+                - len(self.req_to_blocks[request_id])
+            )
+            if num_new_blocks > 0:
+                if request_id in self._allocated_block_reqs:
+                    # Old request. Needs at most 1 more blocks as we can reuse the
+                    # speculative blocks in previous step.
+                    num_new_blocks = 1
+                else:
+                    # First prefill. Allocate 1 block for running state and the
+                    # speculative blocks.
+                    num_new_blocks = 1 + self.num_speculative_blocks
+
+            num_evictable_computed_blocks = self._get_num_evictable_blocks(
+                new_computed_blocks
+            )
+            return num_new_blocks + num_evictable_computed_blocks
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if self.mamba_cache_mode != "align":
+            # Allocate extra `num_speculative_blocks` blocks for
+            # speculative decoding (MTP/EAGLE) with linear attention.
+            if self.num_speculative_blocks > 0:
+                num_tokens += self.block_size * self.num_speculative_blocks
+            return super().allocate_new_blocks(
+                request_id, num_tokens, num_tokens_main_model
+            )
+        else:
+            # We don't allocate blocks for lookahead tokens in align mode, because if
+            # x * block_size tokens are scheduled, num_tokens is
+            # x * block_size + num_lookahead_tokens and breaks the alignment.
+            # We can ignore lookahead tokens because current draft models don't have
+            # mamba layers.
+            num_tokens = num_tokens_main_model
+            req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
+            # NOTE(tdouble): this is an over-estimate of how many blocks we need because
+            # num_tokens can include draft tokens that will later be rejected.
+            num_required_blocks = (
+                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
+            )
+            if num_required_blocks == len(req_blocks):
+                return []
+            else:
+                assert num_required_blocks > len(req_blocks), (
+                    "num_required_blocks "
+                    f"{num_required_blocks} < len(req_blocks) {len(req_blocks)}"
+                )
+                prev_block_len = len(req_blocks)
+                blocks_allocated = request_id in self._allocated_block_reqs
+                # Record the last state block
+                if blocks_allocated:
+                    # We always save the running state at the last
+                    # (1 + num_speculative_blocks) block
+                    self.last_state_block_idx[request_id] = (
+                        prev_block_len - 1 - self.num_speculative_blocks
+                    )
+                elif prev_block_len > 0:
+                    # When a new request hits the prefix cache, the last block
+                    # saves the hit state.
+                    self.last_state_block_idx[request_id] = prev_block_len - 1
+
+                num_skipped_blocks = (
+                    num_required_blocks - self.num_speculative_blocks - 1
+                )
+                # null blocks
+                if prev_block_len < num_skipped_blocks:
+                    req_blocks.extend(
+                        [
+                            self._null_block
+                            for _ in range(prev_block_len, num_skipped_blocks)
+                        ]
+                    )
+
+                if blocks_allocated:
+                    # reuse previous speculative blocks in this step
+                    for block_idx in range(
+                        prev_block_len - self.num_speculative_blocks, prev_block_len
+                    ):
+                        if block_idx < num_skipped_blocks:
+                            req_blocks.append(req_blocks[block_idx])
+                            req_blocks[block_idx] = self._null_block
+                        else:
+                            break
+                num_new_blocks = num_required_blocks - len(req_blocks)
+                if blocks_allocated:
+                    assert num_new_blocks <= 1
+                else:
+                    assert num_new_blocks <= self.num_speculative_blocks + 1
+                new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+                req_blocks.extend(new_blocks)
+                self._allocated_block_reqs.add(request_id)
+                return req_blocks[prev_block_len:]
+
+    def free(self, request_id: str) -> None:
+        if self.mamba_cache_mode == "align":
+            self._allocated_block_reqs.discard(request_id)
+            self.last_state_block_idx.pop(request_id, None)
+        super().free(request_id)
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens whose mamba state are not needed anymore. Mamba only
+        need to keep the state of the last computed token, so we return
+        num_computed_tokens - 1.
+        """
+        return num_computed_tokens - 1
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        alignment_tokens: int | None = None,
+    ) -> None:
+        num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
+        super().cache_blocks(request, num_tokens, alignment_tokens=alignment_tokens)
+        num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
+        if num_cached_blocks_after > num_cached_blocks_before:
+            for block in self.req_to_blocks[request.request_id][
+                num_cached_blocks_before:num_cached_blocks_after
+            ]:
+                if block.is_null:
+                    continue
+                assert block.block_hash is not None
+                self.cached_blocks_this_step.add(block.block_hash)
+
+    def new_step_starts(self) -> None:
+        self.cached_blocks_this_step.clear()
+
+
+class CrossAttentionManager(SingleTypeKVCacheManager):
+    """Manager for cross-attention KV cache in encoder-decoder models."""
+
+    def allocate_new_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # We do not cache blocks for cross-attention to be shared between
+        # requests, so  `new_computed_blocks` should always be empty.
+        assert len(new_computed_blocks) == 0
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        alignment_tokens: int | None = None,
+    ) -> None:
+        # We do not cache blocks for cross-attention to be shared between
+        # requests, so this method is not relevant.
+        raise ValueError("Should not be called as prefix caching is disabled.")
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        # Cross-attention blocks contain request-specific encoder states
+        # and are not shared between different requests
+        return 0
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(kv_cache_spec, CrossAttentionSpec), (
+            "CrossAttentionManager can only be used for cross-attention groups"
+        )
+        # Cross-attention does not benefit from prefix caching since:
+        # 1. Encoder states are unique per request (different audio/image
+        #    inputs)
+        # 2. Encoder states are computed once per request, not incrementally
+        # 3. No reusable prefix exists between different multimodal inputs
+        # Return empty blocks to indicate no cache hits
+        raise NotImplementedError("CrossAttentionManager does not support caching")
+
+
+class SinkFullAttentionManager(FullAttentionManager):
+    def __init__(
+        self,
+        kv_cache_spec: SinkFullAttentionSpec,
+        block_pool: BlockPool,
+        enable_caching: bool,
+        kv_cache_group_id: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+        max_model_len: int | None = None,
+    ):
+        super().__init__(
+            kv_cache_spec,
+            block_pool,
+            enable_caching,
+            kv_cache_group_id,
+            dcp_world_size,
+            pcp_world_size,
+            max_model_len=max_model_len,
+        )
+        sink_len = kv_cache_spec.sink_len
+        assert sink_len is not None and sink_len > 0 and sink_len % self.block_size == 0
+        num_sink_block = sink_len // self.block_size
+        self.sink_blocks = self.block_pool.free_block_queue.popleft_n(num_sink_block)
+
+
+spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
+    FullAttentionSpec: FullAttentionManager,
+    TQFullAttentionSpec: FullAttentionManager,
+    MLAAttentionSpec: MLAAttentionManager,
+    HiddenStateCacheSpec: FullAttentionManager,
+    SlidingWindowSpec: SlidingWindowManager,
+    SlidingWindowMLASpec: SlidingWindowMLAManager,
+    ChunkedLocalAttentionSpec: ChunkedLocalAttentionManager,
+    MambaSpec: MambaManager,
+    CrossAttentionSpec: CrossAttentionManager,
+    SinkFullAttentionSpec: SinkFullAttentionManager,
+}
+
+
+def get_manager_for_kv_cache_spec(
+    kv_cache_spec: KVCacheSpec,
+    max_num_batched_tokens: int,
+    max_model_len: int,
+    **kwargs,
+) -> SingleTypeKVCacheManager:
+    manager_class = spec_manager_map[type(kv_cache_spec)]
+    kwargs["max_model_len"] = max_model_len
+    # SlidingWindow / ChunkedLocalAttention managers recycle blocks across
+    # chunks; the runtime admission cap must match the recycling-aware bound
+    # the startup pool sizer uses (single source of truth: the spec method).
+    if isinstance(kv_cache_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
+        kwargs["max_admission_blocks_per_request"] = (
+            kv_cache_spec.max_admission_blocks_per_request(
+                max_num_batched_tokens=max_num_batched_tokens,
+                max_model_len=max_model_len,
+            )
+        )
+    manager = manager_class(kv_cache_spec, **kwargs)
+    return manager


### PR DESCRIPTION
Long-context agent sessions re-prefilled ~400K tokens (235 s) on the first call of most turns, although an identical resend hit 100%. Both causes are in `vllm/v1/core/single_type_kv_cache_manager.py`; this PR adds a single-file overlay (91 changed lines), env-gated, with the old behaviour one variable away.

## Root cause

1. **Unbounded prompt-block protection.** `MLAAttentionManager.cache_blocks` (opted in for `model_version == "deepseek_v4"`) and `SlidingWindowMLAManager.cache_blocks` call `_protect_prompt_blocks`, which `touch()`es prompt pages — an extra `ref_cnt` that outlives the request. The only cap, `2 * max_model_len / block_size`, is 8,192–524,288 pages per group at `max_model_len=1M`, i.e. larger than the whole pool (12,621 pages). The protected set therefore grows ~30–60 pages on every request (+0.45–0.79 pp of the pool), never shrinks while idle, and is released only FIFO under allocation pressure — evicting the oldest conversation's prefix first.
2. **Sliding-window churn through the shared LRU.** DSv4's compressor/indexer groups use pages of a few tokens. `remove_skipped_blocks` frees each skipped page to the global free queue and the next `allocate_new_blocks` pops fresh pages from the queue head. One 354K-token prefill cycles the whole pool several times and evicts every other request's cached pages — with any amount of free space. (1) was the shield against (2).

Effect for an agent: the first call of a user turn (which cannot hit at the previous prompt boundary once the prior round's reasoning is stripped) re-prefills ~400K tokens instead of 1–4 s, and any large intervening request destroys the conversation's prefix.

## Fix

- Cap the protected set to a fraction of the pool, shared across the KV groups: `VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION` (default 0.30; `-1` restores the unbounded behaviour).
- Sliding-window groups keep the pages they skip in a per-request recycle list (`ref_cnt` kept, hash evicted) and reuse them for that request's next allocations; leftovers are freed in `free()`. Shared or protected pages (`ref_cnt != 1`) are freed as before. `VLLM_SWA_RECYCLE_SKIPPED_BLOCKS=0` disables it. Admission accounting is unchanged (conservative: it ignores recyclable pages).

Both launchers pass `VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION=${PROTECTED_FRACTION:-0.30}` and `VLLM_SWA_RECYCLE_SKIPPED_BLOCKS=${SWA_RECYCLE:-1}`, mount `/var/tmp/patch6-single_type_kv_cache_manager.py` read-only like Patches 3/4, and check it in the preflight.

## Validation (2× DGX Spark, TP=2, DeepSeek-V4-Flash-Vision-Exp, DSpark k=5)

```
                                        stock image          cap only             cap + recycle (this PR)
354K prompt, identical resend           100%  1.3 s          100%  1.3 s          100%  1.2 s
second 354K tree, then first again      0%    236 s (cold)   0%    229 s (cold)   100%  1.2 s
second tree again                       0%    235 s (cold)   0%    230 s (cold)   100%  1.3 s
third tree, then first / second         —                    —                    100% / 100%
first tree + 300-token decode, resend   —                    —                    100% (6.8 s decode)
idle KV usage per small request         +0.47 pp             +0.46 pp             +0.48 pp until the cap engages
idle KV usage after 80 small requests   ~37% (extrapolated)  15.2%                capped
greedy output vs stock                  reference            identical            identical
1200-token prose generation, no think   —                    —                    coherent, 35.6 tok/s
reasoning_effort=max                    —                    —                    reasoning + answer returned
```

Bisection from a clean boot (`ratchet-*.log`): removing `--async-scheduling` changes nothing (+0.45 pp/request); removing DSpark reduces the residue to +0.14 pp but does not remove it — DSpark amplifies the problem, the cause is the KV manager.

Analysis and patch by Claude (Fable 5.1) via Claude Code; run and validated on my cluster.

## Files

- `recipe/overlay/vllm/v1/core/single_type_kv_cache_manager.py` — overlay file (based on the probe-c image's module)
- `patches/0006-kv-cache-prompt-protection-cap-and-swa-recycle.patch` — the 91-line unified diff
- `docs/PATCH6-KV-CACHE-PREFIX-EVICTION.md`, entry in `docs/PATCHES.md`, README staging line
- `docs/patch6-validation/` — raw logs behind every number above
- `launchers/ds4-vision-tp2.sh`, `launchers/ds4-vision-tp4.sh` — preflight guard, read-only mount, two env knobs
- `CURRENT.md` (preflight bullet + knobs, launcher hashes refreshed), `.env.dspark.example` (`PROTECTED_FRACTION`, `SWA_RECYCLE`)

---

**Which line of CURRENT.md does this change?**
The preflight bullet: "Patch 3 (`patch3-scheduler.py`), Patch 4 (`spec-dspark.py`) **and** the four vision port files … The launcher checks all six and exits if any is missing." — now seven staged files (Patch 6 added) plus a new bullet documenting the two env knobs. Launcher hashes refreshed with `bash tools/check-current.sh --write`.

**What is the new value, and what number proves it?**
New: `VLLM_PROTECTED_PROMPT_BLOCKS_FRACTION=0.30` and `VLLM_SWA_RECYCLE_SKIPPED_BLOCKS=1` (both launchers) with the Patch 6 mount. Before → after: a 354,481-token prompt re-sent after another 354K-token prefill hits 0% and re-prefills cold in 236 s → hits 100% in 1.2 s. Measurement: a real agent transcript as the prompt, `temperature=0`, `max_tokens=1`, `reasoning_effort=max`; equivalence check `temperature=0`, `seed=1`, byte-identical to the stock image. Logs: `docs/patch6-validation/validate_patch6.log` (fixed), `replay.log` (stock), `ratchet-{baseline,noasync,nospec}.log` (bisection), `validate_patch5.log` (cap only). No serving flag that affects speed is changed.

**Tested on**
2× DGX Spark GB10, TP=2 over RoCE; `vllm-dspark-runtime` (probe-c / keys-concurrency-p2b family, vLLM `0.21.1rc1.dev339+g1967a5627bc3`) with Patches 3/4 mounted; weights `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp` @ `86f746b36186f0e567729a5c06a8c918caba82a9`; 2026-09-06. The TP4 launcher carries the identical change but was **not run** (I only have two Sparks); the KV manager runs on the head, so the change does not depend on TP size.

****Independent validation:** #55 (second 2× DGX Spark pair, same vLLM line): both halves logged at boot, ~99.8% prefix-cache hit on the next request vs. 0% stock, idle KV ~80% → ~7%.

Checklist**
- [x] I rebased on current `main` (branch base is `d841fdb`, the current `main`)
- [x] `CURRENT.md` updated in this PR if a launcher or a serving flag changed, and `bash tools/check-current.sh --write` was run (`tools/check-current.sh` passes)
- [x] Speed numbers are from real prompts (354K agent transcript for the cache timings, prose essay for tok/s); the 235 s figures are cold prefill, the 1.2 s figures are the warm hits this PR restores; no counting-prompt numbers
